### PR TITLE
ci: fix default release version bump action to be patch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Bump version
         id: version
         run: |
-          BUMP=${{ inputs.bump || 'minor' }}
+          BUMP=${{ inputs.bump || 'patch' }}
           make release BUMP=$BUMP
           version=$(sed -n 's/.*Version = "\([0-9]*\.[0-9]*\.[0-9]*\)".*/\1/p' internal/version.go)
           echo "version=$version" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What is the Change
Changes the Github release workflow to increment version number by patch, not minor version

## Why do we need this?

We were bumping versions wayyyyyy to fast

## New modules introduced

None

## How was it tested?
Fuck it well do it live


