### PR TITLE
docs: add bug, feature, and documentation issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: Bug Report
+description: Report a bug or unexpected behavior in the ops CLI
+labels: ["bug"]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: ops CLI Version
+      description: Run `ops --version` and paste the output here.
+      placeholder: "e.g. 1.2.3"
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      description: OS name and version (e.g. macOS 14.4, Ubuntu 22.04, Windows 11).
+      placeholder: "e.g. macOS 14.4"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction Steps
+      description: Step-by-step instructions to reproduce the issue.
+      placeholder: |
+        1. Create an Opsfile with...
+        2. Run `ops ...`
+        3. See error
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,31 @@
+name: Documentation
+description: Report a documentation issue or suggest an improvement
+labels: ["documentation"]
+body:
+  - type: dropdown
+    id: request_type
+    attributes:
+      label: Request Type
+      options:
+        - Suggestion
+        - Missing or incorrect information
+        - Typo
+    validations:
+      required: true
+
+  - type: input
+    id: link
+    attributes:
+      label: Link to Document or Page
+      description: URL or file path to the relevant documentation.
+      placeholder: "e.g. https://github.com/sean_seannery/opsfile/blob/main/README.md or docs/some-file.md"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the issue or suggestion in detail.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,19 @@
+name: Feature Request
+description: Propose a new feature or enhancement for the ops CLI
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem This Solves
+      description: What problem or limitation are you running into? Why is this needed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: Describe your proposed solution. Include any relevant examples, commands, or Opsfile syntax.
+    validations:
+      required: true


### PR DESCRIPTION
## Key Changes

Adds three GitHub issue templates under `.github/ISSUE_TEMPLATE/`:
- `bug_report.yml` — requires ops CLI version, OS, description, and reproduction steps
- `feature_request.yml` — requires a problem statement and proposal section
- `documentation.yml` — includes a dropdown for request type (suggestion, missing/wrong info, typo), a link field, and description

## Why do we need this?

Gives contributors a consistent, structured way to report bugs, propose features, and flag documentation issues via GitHub's issue form UI.

## New modules or other dependencies introduced

None

## How was this tested?

Validated YAML structure manually; no code changes so existing tests are unaffected.