### PR TITLE
refactor(flags): migrate flag_parser to spf13/pflag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module sean_seannery/opsfile
 
 go 1.25.5
+
+require github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
+github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/internal/command_resolver.go
+++ b/internal/command_resolver.go
@@ -74,7 +74,7 @@ func substituteVars(line, env string, vars OpsVariables) (string, error) {
 
 		end := strings.Index(remaining, ")")
 		if end == -1 {
-			// No closing paren — write the literal "$(" and continue.
+			// No closing paren — treat "$(" as a literal and continue scanning.
 			b.WriteString("$(")
 			continue
 		}

--- a/internal/flag_parser.go
+++ b/internal/flag_parser.go
@@ -2,10 +2,10 @@ package internal
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"runtime"
-	"slices"
+
+	pflag "github.com/spf13/pflag"
 )
 
 // the structure of the ops commandline argument should be
@@ -34,16 +34,13 @@ type Args struct {
 // Returns ErrHelp if -h, --help, or -? is passed (usage is printed to stderr).
 // Returns an error for unrecognised flags.
 func ParseOpsFlags(osArgs []string) (OpsFlags, []string, error) {
-	fs := flag.NewFlagSet("ops", flag.ContinueOnError)
+	fs := pflag.NewFlagSet("ops", pflag.ContinueOnError)
+	fs.SetInterspersed(false) // stop flag parsing at the first non-flag arg (stdlib flag behaviour)
 
-	dir := fs.String("D", "", "use Opsfile in the given `directory`")
-	fs.StringVar(dir, "directory", "", "use Opsfile in the given `directory`")
-	dryRun := fs.Bool("d", false, "print commands without executing")
-	fs.BoolVar(dryRun, "dry-run", false, "print commands without executing")
-	silent := fs.Bool("s", false, "execute without printing output")
-	fs.BoolVar(silent, "silent", false, "execute without printing output")
-	ver := fs.Bool("v", false, "print the ops version and exit")
-	fs.BoolVar(ver, "version", false, "print the ops version and exit")
+	dir := fs.StringP("directory", "D", "", "use Opsfile in the given `directory`")
+	dryRun := fs.BoolP("dry-run", "d", false, "print commands without executing")
+	silent := fs.BoolP("silent", "s", false, "execute without printing output")
+	ver := fs.BoolP("version", "v", false, "print the ops version and exit")
 
 	fs.Usage = func() {
 		fmt.Fprintf(fs.Output(), "ops version %s (commit: %s) %s/%s\n\n", Version, Commit, runtime.GOOS, runtime.GOARCH)
@@ -54,18 +51,20 @@ Usage: ops [flags] <environment> <command> [command-args]
       ex. 'ops preprod open-dashboard' or 'ops --dry-run prod tail-logs'
 
 Flags:`)
-
+		fmt.Fprintln(fs.Output())
 		fs.PrintDefaults()
 	}
 
 	// -? is not a valid flag name; handle it before fs.Parse.
-	if slices.Contains(osArgs, "-?") {
-		fs.Usage()
-		return OpsFlags{}, nil, ErrHelp
+	for _, a := range osArgs {
+		if a == "-?" {
+			fs.Usage()
+			return OpsFlags{}, nil, ErrHelp
+		}
 	}
 
 	if err := fs.Parse(osArgs); err != nil {
-		if errors.Is(err, flag.ErrHelp) {
+		if errors.Is(err, pflag.ErrHelp) {
 			return OpsFlags{}, nil, ErrHelp
 		}
 		return OpsFlags{}, nil, err

--- a/internal/flag_parser_test.go
+++ b/internal/flag_parser_test.go
@@ -94,7 +94,7 @@ func TestParseOpsFlags(t *testing.T) {
 		{
 			name:       "unknown flag returns error",
 			input:      []string{"-z"},
-			wantErrSub: "flag provided but not defined",
+			wantErrSub: "unknown shorthand flag",
 		},
 		{
 			name:      "multiple flags combined -d -s",
@@ -110,7 +110,7 @@ func TestParseOpsFlags(t *testing.T) {
 		{
 			name:       "unknown long flag --foobar",
 			input:      []string{"--foobar"},
-			wantErrSub: "flag provided but not defined",
+			wantErrSub: "unknown flag: --foobar",
 		},
 		{
 			name:      "flag after positional treated as positional",


### PR DESCRIPTION
## Key Changes

- Migrate `internal/flag_parser.go` from stdlib `flag` to `github.com/spf13/pflag`
- Each flag now uses a single `*P` call (e.g. `BoolP("dry-run", "d", ...)`) eliminating the double-registration boilerplate required by stdlib `flag` for short/long aliases
- Add `fs.SetInterspersed(false)` to preserve existing behaviour: flag parsing stops at the first non-flag positional argument
- Update two error message substring assertions in `flag_parser_test.go` to match pflag's error phrasing
- Add inline comment to `command_resolver.go` explaining unclosed-paren passthrough in `substituteVars`
- Add `go.mod` / `go.sum` entries for `github.com/spf13/pflag v1.0.10`

## Why do we need this?

stdlib `flag` requires two separate calls to register a flag with both a short name (`-d`) and a long name (`--dry-run`). `spf13/pflag` supports this natively in one call, halving the flag registration code and making intent clearer. Part of the Issue #9 code quality pass.

## New modules or other dependencies introduced

- `github.com/spf13/pflag v1.0.10` — POSIX/GNU-compatible flag parsing. Widely used (Kubernetes, Helm, and Cobra all depend on it) and actively maintained.

## How was this tested?

All existing tests pass. `make lint`, `make test`, and `make build` verified in an isolated git worktree. Manual smoke test confirmed `--help`, `-h`, and `-?` all print usage correctly.