### PR TITLE
refactor(tests): migrate test assertions to testify/assert and require

### DIFF
--- a/cmd/ops/main.go
+++ b/cmd/ops/main.go
@@ -17,7 +17,7 @@ const opsFileName string = "Opsfile"
 func main() {
 	slog.SetLogLoggerLevel(slog.LevelWarn)
 
-	flags, positionals, err := internal.ParseOpsFlags(os.Args[1:])
+	flags, positionals, err := internal.ParseOpsFlags(os.Args[1:], nil)
 	if errors.Is(err, internal.ErrHelp) {
 		os.Exit(0)
 	}

--- a/cmd/ops/main_test.go
+++ b/cmd/ops/main_test.go
@@ -3,60 +3,47 @@ package main
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // realPath resolves symlinks so tests work on macOS where /var -> /private/var.
 func realPath(t *testing.T, path string) string {
 	t.Helper()
 	resolved, err := filepath.EvalSymlinks(path)
-	if err != nil {
-		t.Fatalf("EvalSymlinks(%q): %v", path, err)
-	}
+	require.NoError(t, err, "EvalSymlinks(%q)", path)
 	return resolved
 }
 
 func TestGetClosestOpsfilePath_FoundInCwd(t *testing.T) {
 	tmp := realPath(t, t.TempDir())
-	if err := os.WriteFile(filepath.Join(tmp, "Opsfile"), []byte(""), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	err := os.WriteFile(filepath.Join(tmp, "Opsfile"), []byte(""), 0o644)
+	require.NoError(t, err)
 
 	orig, _ := os.Getwd()
 	t.Cleanup(func() { os.Chdir(orig) })
 	os.Chdir(tmp)
 
 	got, err := getClosestOpsfilePath()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got != tmp {
-		t.Errorf("got %q, want %q", got, tmp)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, tmp, got)
 }
 
 func TestGetClosestOpsfilePath_FoundInParent(t *testing.T) {
 	parent := realPath(t, t.TempDir())
 	child := filepath.Join(parent, "subdir")
-	if err := os.Mkdir(child, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(parent, "Opsfile"), []byte(""), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.Mkdir(child, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(parent, "Opsfile"), []byte(""), 0o644))
 
 	orig, _ := os.Getwd()
 	t.Cleanup(func() { os.Chdir(orig) })
 	os.Chdir(child)
 
 	got, err := getClosestOpsfilePath()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got != parent {
-		t.Errorf("got %q, want %q", got, parent)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, parent, got)
 }
 
 func TestGetClosestOpsfilePath_NotFound(t *testing.T) {
@@ -67,38 +54,24 @@ func TestGetClosestOpsfilePath_NotFound(t *testing.T) {
 	os.Chdir(tmp)
 
 	_, err := getClosestOpsfilePath()
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), "could not find Opsfile") {
-		t.Errorf("error %q does not mention Opsfile not found", err.Error())
-	}
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "could not find Opsfile")
 }
 
 func TestGetClosestOpsfilePath_DirectoryNamedOpsfileSkipped(t *testing.T) {
 	parent := realPath(t, t.TempDir())
 	child := filepath.Join(parent, "subdir")
-	if err := os.Mkdir(child, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.Mkdir(child, 0o755))
 	// Create a directory named "Opsfile" in child — should be skipped.
-	if err := os.Mkdir(filepath.Join(child, "Opsfile"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.Mkdir(filepath.Join(child, "Opsfile"), 0o755))
 	// Place the real Opsfile in parent.
-	if err := os.WriteFile(filepath.Join(parent, "Opsfile"), []byte(""), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(parent, "Opsfile"), []byte(""), 0o644))
 
 	orig, _ := os.Getwd()
 	t.Cleanup(func() { os.Chdir(orig) })
 	os.Chdir(child)
 
 	got, err := getClosestOpsfilePath()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got != parent {
-		t.Errorf("got %q, want %q (directory named Opsfile should be skipped)", got, parent)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, parent, got, "directory named Opsfile should be skipped")
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,13 @@ module sean_seannery/opsfile
 
 go 1.25.5
 
-require github.com/spf13/pflag v1.0.10
+require (
+	github.com/spf13/pflag v1.0.10
+	github.com/stretchr/testify v1.11.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/command_resolver_test.go
+++ b/internal/command_resolver_test.go
@@ -1,8 +1,10 @@
 package internal
 
 import (
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // parseFixture is a test helper that parses an inline Opsfile string and
@@ -10,9 +12,7 @@ import (
 func parseFixture(t *testing.T, content string) (OpsVariables, map[string]OpsCommand) {
 	t.Helper()
 	vars, commands, err := ParseOpsFile(writeTempOpsfile(t, content))
-	if err != nil {
-		t.Fatalf("ParseOpsFile: %v", err)
-	}
+	require.NoError(t, err, "ParseOpsFile")
 	return vars, commands
 }
 
@@ -26,30 +26,17 @@ list-instance-ips:
         aws ecs --list-instances
 `)
 	got, err := Resolve("list-instance-ips", "prod", commands, vars)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	want := []string{`aws ec2 --list-instances`, `echo "done"`}
-	if len(got.Lines) != len(want) {
-		t.Fatalf("got %d lines, want %d: %v", len(got.Lines), len(want), got.Lines)
-	}
-	for i, w := range want {
-		if got.Lines[i] != w {
-			t.Errorf("line %d: got %q, want %q", i, got.Lines[i], w)
-		}
-	}
+	assert.Equal(t, want, got.Lines)
 }
 
 func TestResolve_EmptyCommandsMap(t *testing.T) {
 	commands := map[string]OpsCommand{}
 	vars := OpsVariables{}
 	_, err := Resolve("anything", "prod", commands, vars)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), "not found") {
-		t.Errorf("error %q does not contain 'not found'", err.Error())
-	}
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "not found")
 }
 
 func TestResolve_CommandWithEmptyShellLines(t *testing.T) {
@@ -58,12 +45,8 @@ func TestResolve_CommandWithEmptyShellLines(t *testing.T) {
 	}
 	vars := OpsVariables{}
 	got, err := Resolve("empty", "prod", commands, vars)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(got.Lines) != 0 {
-		t.Errorf("got %d lines, want 0", len(got.Lines))
-	}
+	require.NoError(t, err)
+	assert.Empty(t, got.Lines)
 }
 
 func TestResolve_MultipleVariablesInOneLine(t *testing.T) {
@@ -76,13 +59,8 @@ my-cmd:
         echo $(A) $(B)
 `)
 	got, err := Resolve("my-cmd", "prod", commands, vars)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	want := "echo hello world"
-	if got.Lines[0] != want {
-		t.Errorf("got %q, want %q", got.Lines[0], want)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "echo hello world", got.Lines[0])
 }
 
 func TestResolve_VariableUsedMultipleTimes(t *testing.T) {
@@ -94,13 +72,8 @@ my-cmd:
         echo $(A) and $(A)
 `)
 	got, err := Resolve("my-cmd", "prod", commands, vars)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	want := "echo val and val"
-	if got.Lines[0] != want {
-		t.Errorf("got %q, want %q", got.Lines[0], want)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "echo val and val", got.Lines[0])
 }
 
 func TestResolve_UnclosedDollarParen(t *testing.T) {
@@ -111,13 +84,8 @@ func TestResolve_UnclosedDollarParen(t *testing.T) {
 	}
 	vars := OpsVariables{}
 	got, err := Resolve("my-cmd", "prod", commands, vars)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	want := "echo $(incomplete"
-	if got.Lines[0] != want {
-		t.Errorf("got %q, want %q", got.Lines[0], want)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "echo $(incomplete", got.Lines[0])
 }
 
 func TestResolve_MixedIdentifierAndNonIdentifier(t *testing.T) {
@@ -129,13 +97,8 @@ my-cmd:
         $(VAR) $(shell cmd)
 `)
 	got, err := Resolve("my-cmd", "prod", commands, vars)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	want := "hello $(shell cmd)"
-	if got.Lines[0] != want {
-		t.Errorf("got %q, want %q", got.Lines[0], want)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "hello $(shell cmd)", got.Lines[0])
 }
 
 func TestResolve_DefaultFallbackVariableScoping(t *testing.T) {
@@ -148,13 +111,8 @@ my-cmd:
         echo $(ACCOUNT)
 `)
 	got, err := Resolve("my-cmd", "prod", commands, vars)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	want := "echo prod-acct"
-	if got.Lines[0] != want {
-		t.Errorf("got %q, want %q", got.Lines[0], want)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "echo prod-acct", got.Lines[0])
 }
 
 func TestResolve_SameVarReferencedTwice(t *testing.T) {
@@ -166,12 +124,8 @@ my-cmd:
         $(VAR) $(VAR)
 `)
 	got, err := Resolve("my-cmd", "prod", commands, vars)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got.Lines[0] != "x x" {
-		t.Errorf("got %q, want %q", got.Lines[0], "x x")
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "x x", got.Lines[0])
 }
 
 func TestResolve_UnclosedDollarParenAtEnd(t *testing.T) {
@@ -182,13 +136,8 @@ func TestResolve_UnclosedDollarParenAtEnd(t *testing.T) {
 	}
 	vars := OpsVariables{}
 	got, err := Resolve("my-cmd", "prod", commands, vars)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	want := "echo $("
-	if got.Lines[0] != want {
-		t.Errorf("got %q, want %q", got.Lines[0], want)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "echo $(", got.Lines[0])
 }
 
 func TestResolve_EmptyToken(t *testing.T) {
@@ -199,13 +148,8 @@ func TestResolve_EmptyToken(t *testing.T) {
 	}
 	vars := OpsVariables{}
 	got, err := Resolve("my-cmd", "prod", commands, vars)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	want := "echo $()"
-	if got.Lines[0] != want {
-		t.Errorf("got %q, want %q", got.Lines[0], want)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "echo $()", got.Lines[0])
 }
 
 func TestResolve_ScopedLookupPriority(t *testing.T) {
@@ -219,12 +163,8 @@ func TestResolve_ScopedLookupPriority(t *testing.T) {
 		"HOST":      "default.example.com",
 	}
 	got, err := Resolve("my-cmd", "prod", commands, vars)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got.Lines[0] != "echo prod.example.com" {
-		t.Errorf("got %q, want scoped value", got.Lines[0])
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "echo prod.example.com", got.Lines[0])
 }
 
 func TestResolve_UnscopedFallbackDirect(t *testing.T) {
@@ -237,12 +177,8 @@ func TestResolve_UnscopedFallbackDirect(t *testing.T) {
 		"HOST": "default.example.com",
 	}
 	got, err := Resolve("my-cmd", "prod", commands, vars)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got.Lines[0] != "echo default.example.com" {
-		t.Errorf("got %q, want unscoped fallback", got.Lines[0])
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "echo default.example.com", got.Lines[0])
 }
 
 func TestResolve_MissingVariableReturnsError(t *testing.T) {
@@ -253,12 +189,8 @@ func TestResolve_MissingVariableReturnsError(t *testing.T) {
 	}
 	vars := OpsVariables{}
 	_, err := Resolve("my-cmd", "prod", commands, vars)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), "not defined") {
-		t.Errorf("error %q does not contain 'not defined'", err.Error())
-	}
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "not defined")
 }
 
 func TestResolve_DefaultFallback(t *testing.T) {
@@ -270,16 +202,9 @@ tail-logs:
         aws cloudwatch logs --tail $(AWS_ACCOUNT)
 `)
 	got, err := Resolve("tail-logs", "prod", commands, vars)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(got.Lines) != 1 {
-		t.Fatalf("got %d lines, want 1: %v", len(got.Lines), got.Lines)
-	}
-	want := "aws cloudwatch logs --tail 1234567"
-	if got.Lines[0] != want {
-		t.Errorf("got %q, want %q", got.Lines[0], want)
-	}
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "aws cloudwatch logs --tail 1234567", got.Lines[0])
 }
 
 func TestResolve_LocalOverridesDefault(t *testing.T) {
@@ -291,15 +216,9 @@ tail-logs:
         docker logs myapp --follow
 `)
 	got, err := Resolve("tail-logs", "local", commands, vars)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(got.Lines) != 1 {
-		t.Fatalf("got %d lines, want 1: %v", len(got.Lines), got.Lines)
-	}
-	if got.Lines[0] != "docker logs myapp --follow" {
-		t.Errorf("got %q, want local block line", got.Lines[0])
-	}
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "docker logs myapp --follow", got.Lines[0])
 }
 
 func TestResolve_ScopedPriority(t *testing.T) {
@@ -312,12 +231,8 @@ tail-logs:
         echo $(AWS_ACCOUNT)
 `)
 	got, err := Resolve("tail-logs", "prod", commands, vars)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got.Lines[0] != "echo scoped" {
-		t.Errorf("got %q, expected scoped value", got.Lines[0])
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "echo scoped", got.Lines[0])
 }
 
 func TestResolve_UnscopedFallback(t *testing.T) {
@@ -329,12 +244,8 @@ tail-logs:
         echo $(AWS_ACCOUNT)
 `)
 	got, err := Resolve("tail-logs", "prod", commands, vars)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got.Lines[0] != "echo unscoped" {
-		t.Errorf("got %q, expected unscoped value", got.Lines[0])
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "echo unscoped", got.Lines[0])
 }
 
 func TestResolve_CommandNotFound(t *testing.T) {
@@ -344,12 +255,8 @@ my-cmd:
         echo hello
 `)
 	_, err := Resolve("nonexistent", "prod", commands, vars)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), "not found") {
-		t.Errorf("error %q does not contain 'not found'", err.Error())
-	}
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "not found")
 }
 
 func TestResolve_EnvNotFoundNoDefault(t *testing.T) {
@@ -359,12 +266,8 @@ my-cmd:
         echo hello
 `)
 	_, err := Resolve("my-cmd", "staging", commands, vars)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), "no default") {
-		t.Errorf("error %q does not contain 'no default'", err.Error())
-	}
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "no default")
 }
 
 func TestResolve_VariableNotDefined(t *testing.T) {
@@ -374,12 +277,8 @@ my-cmd:
         echo $(MISSING_VAR)
 `)
 	_, err := Resolve("my-cmd", "prod", commands, vars)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), "not defined") {
-		t.Errorf("error %q does not contain 'not defined'", err.Error())
-	}
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "not defined")
 }
 
 func TestResolve_NonIdentifierPassthrough(t *testing.T) {
@@ -389,13 +288,8 @@ my-cmd:
         echo $(aws ec2 describe-instances)
 `)
 	got, err := Resolve("my-cmd", "prod", commands, vars)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	want := "echo $(aws ec2 describe-instances)"
-	if got.Lines[0] != want {
-		t.Errorf("got %q, want %q", got.Lines[0], want)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "echo $(aws ec2 describe-instances)", got.Lines[0])
 }
 
 func TestResolve_MultiLineCommand(t *testing.T) {
@@ -409,21 +303,12 @@ deploy:
         echo "done in $(REGION)"
 `)
 	got, err := Resolve("deploy", "prod", commands, vars)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	want := []string{
 		"aws ecs describe-clusters --cluster my-cluster --region us-east-1",
 		`echo "done in us-east-1"`,
 	}
-	if len(got.Lines) != len(want) {
-		t.Fatalf("got %d lines, want %d: %v", len(got.Lines), len(want), got.Lines)
-	}
-	for i, w := range want {
-		if got.Lines[i] != w {
-			t.Errorf("line %d: got %q, want %q", i, got.Lines[i], w)
-		}
-	}
+	assert.Equal(t, want, got.Lines)
 }
 
 // --- Shell environment variable injection tests ---
@@ -436,12 +321,8 @@ func TestResolveVar_UnscopedShellEnvFallback(t *testing.T) {
 		}},
 	}
 	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got.Lines[0] != "echo from-shell" {
-		t.Errorf("got %q, want shell unscoped value", got.Lines[0])
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "echo from-shell", got.Lines[0])
 }
 
 func TestResolveVar_EnvScopedShellEnv(t *testing.T) {
@@ -452,12 +333,8 @@ func TestResolveVar_EnvScopedShellEnv(t *testing.T) {
 		}},
 	}
 	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got.Lines[0] != "echo shell-scoped" {
-		t.Errorf("got %q, want shell env-scoped value", got.Lines[0])
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "echo shell-scoped", got.Lines[0])
 }
 
 func TestResolveVar_OpsfileEnvScopedBeatsShellEnvScoped(t *testing.T) {
@@ -469,12 +346,8 @@ func TestResolveVar_OpsfileEnvScopedBeatsShellEnvScoped(t *testing.T) {
 	}
 	vars := OpsVariables{"prod_VAR": "opsfile-scoped"}
 	got, err := Resolve("my-cmd", "prod", commands, vars)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got.Lines[0] != "echo opsfile-scoped" {
-		t.Errorf("got %q, want Opsfile env-scoped value", got.Lines[0])
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "echo opsfile-scoped", got.Lines[0])
 }
 
 func TestResolveVar_ShellEnvScopedBeatsOpsfileUnscoped(t *testing.T) {
@@ -486,12 +359,8 @@ func TestResolveVar_ShellEnvScopedBeatsOpsfileUnscoped(t *testing.T) {
 	}
 	vars := OpsVariables{"VAR": "opsfile-unscoped"}
 	got, err := Resolve("my-cmd", "prod", commands, vars)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got.Lines[0] != "echo shell-scoped" {
-		t.Errorf("got %q, want shell env-scoped over Opsfile unscoped", got.Lines[0])
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "echo shell-scoped", got.Lines[0])
 }
 
 func TestResolveVar_OpsfileUnscopedBeatsShellEnvUnscoped(t *testing.T) {
@@ -503,12 +372,8 @@ func TestResolveVar_OpsfileUnscopedBeatsShellEnvUnscoped(t *testing.T) {
 	}
 	vars := OpsVariables{"VAR": "opsfile-unscoped"}
 	got, err := Resolve("my-cmd", "prod", commands, vars)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got.Lines[0] != "echo opsfile-unscoped" {
-		t.Errorf("got %q, want Opsfile unscoped over shell unscoped", got.Lines[0])
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "echo opsfile-unscoped", got.Lines[0])
 }
 
 func TestResolveVar_ShellEnvUnscopedIsLastResort(t *testing.T) {
@@ -519,12 +384,8 @@ func TestResolveVar_ShellEnvUnscopedIsLastResort(t *testing.T) {
 		}},
 	}
 	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got.Lines[0] != "echo shell-unscoped" {
-		t.Errorf("got %q, want shell unscoped as last resort", got.Lines[0])
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "echo shell-unscoped", got.Lines[0])
 }
 
 func TestResolveVar_PriorityChain(t *testing.T) {
@@ -570,13 +431,8 @@ func TestResolveVar_PriorityChain(t *testing.T) {
 				}},
 			}
 			got, err := Resolve("my-cmd", "prod", commands, tc.opsfileVars)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			want := "echo " + tc.want
-			if got.Lines[0] != want {
-				t.Errorf("got %q, want %q", got.Lines[0], want)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, "echo "+tc.want, got.Lines[0])
 		})
 	}
 }
@@ -590,12 +446,8 @@ func TestResolveVar_MixedSources(t *testing.T) {
 		}},
 	}
 	got, err := Resolve("my-cmd", "prod", commands, vars)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got.Lines[0] != "echo from-opsfile from-shell" {
-		t.Errorf("got %q, want mixed source substitution", got.Lines[0])
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "echo from-opsfile from-shell", got.Lines[0])
 }
 
 func TestResolveVar_EmptyShellEnvValue(t *testing.T) {
@@ -606,12 +458,8 @@ func TestResolveVar_EmptyShellEnvValue(t *testing.T) {
 		}},
 	}
 	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got.Lines[0] != "echo " {
-		t.Errorf("got %q, want empty string substitution", got.Lines[0])
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "echo ", got.Lines[0])
 }
 
 func TestResolveVar_NonIdentifierUnaffectedByShellEnv(t *testing.T) {
@@ -622,13 +470,8 @@ func TestResolveVar_NonIdentifierUnaffectedByShellEnv(t *testing.T) {
 		}},
 	}
 	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	want := "echo $(aws ec2 describe-instances)"
-	if got.Lines[0] != want {
-		t.Errorf("got %q, want %q", got.Lines[0], want)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "echo $(aws ec2 describe-instances)", got.Lines[0])
 }
 
 func TestResolveVar_AbsentFromAllSources(t *testing.T) {
@@ -638,10 +481,6 @@ func TestResolveVar_AbsentFromAllSources(t *testing.T) {
 		}},
 	}
 	_, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), "not defined") {
-		t.Errorf("error %q does not contain 'not defined'", err.Error())
-	}
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "not defined")
 }

--- a/internal/executor_test.go
+++ b/internal/executor_test.go
@@ -3,8 +3,10 @@ package internal
 import (
 	"errors"
 	"os/exec"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExecute(t *testing.T) {
@@ -56,53 +58,35 @@ func TestExecute(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			err := Execute(tc.lines, "/bin/sh")
 			if tc.wantErr {
-				if err == nil {
-					t.Fatalf("expected error, got nil")
-				}
+				require.Error(t, err)
 				var exitErr *exec.ExitError
-				if !errors.As(err, &exitErr) {
-					t.Fatalf("expected *exec.ExitError, got %T: %v", err, err)
-				}
-				if exitErr.ExitCode() != tc.wantExitCode {
-					t.Errorf("exit code: got %d, want %d", exitErr.ExitCode(), tc.wantExitCode)
-				}
+				require.True(t, errors.As(err, &exitErr), "expected *exec.ExitError, got %T: %v", err, err)
+				assert.Equal(t, tc.wantExitCode, exitErr.ExitCode())
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			assert.NoError(t, err)
 		})
 	}
 }
 
 func TestExecute_ErrorWrapsCommandString(t *testing.T) {
 	err := Execute([]string{"this-command-does-not-exist-at-all"}, "/bin/sh")
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), "this-command-does-not-exist-at-all") {
-		t.Errorf("error %q does not contain the command string", err.Error())
-	}
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "this-command-does-not-exist-at-all")
 }
 
 func TestExecute_InvalidShellPath(t *testing.T) {
 	err := Execute([]string{"echo hello"}, "/nonexistent/shell/binary")
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
+	require.Error(t, err)
 }
 
 func TestExecute_CommandWithPipe(t *testing.T) {
 	err := Execute([]string{"echo hello | cat"}, "/bin/sh")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	assert.NoError(t, err)
 }
 
 func TestExecute_StderrConnected(t *testing.T) {
 	// A command writing to stderr should not cause an error by itself.
 	err := Execute([]string{"echo error-output >&2"}, "/bin/sh")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	assert.NoError(t, err)
 }

--- a/internal/flag_parser.go
+++ b/internal/flag_parser.go
@@ -3,6 +3,8 @@ package internal
 import (
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"runtime"
 
 	pflag "github.com/spf13/pflag"
@@ -31,10 +33,15 @@ type Args struct {
 
 // ParseOpsFlags parses ops-level flags from osArgs and returns the flag values
 // and the remaining positional arguments.
-// Returns ErrHelp if -h, --help, or -? is passed (usage is printed to stderr).
+// Returns ErrHelp if -h, --help, or -? is passed (usage is printed to usageOutput).
 // Returns an error for unrecognised flags.
-func ParseOpsFlags(osArgs []string) (OpsFlags, []string, error) {
+// If usageOutput is nil, os.Stderr is used.
+func ParseOpsFlags(osArgs []string, usageOutput io.Writer) (OpsFlags, []string, error) {
+	if usageOutput == nil {
+		usageOutput = os.Stderr
+	}
 	fs := pflag.NewFlagSet("ops", pflag.ContinueOnError)
+	fs.SetOutput(usageOutput)
 	fs.SetInterspersed(false) // stop flag parsing at the first non-flag arg (stdlib flag behaviour)
 
 	dir := fs.StringP("directory", "D", "", "use Opsfile in the given `directory`")

--- a/internal/flag_parser_test.go
+++ b/internal/flag_parser_test.go
@@ -1,10 +1,12 @@
 package internal
 
 import (
+	"bytes"
 	"io"
-	"os"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseOpsFlags(t *testing.T) {
@@ -133,79 +135,39 @@ func TestParseOpsFlags(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotFlags, gotPos, err := ParseOpsFlags(tc.input)
+			gotFlags, gotPos, err := ParseOpsFlags(tc.input, io.Discard)
 
 			if tc.wantErr != nil {
-				if err != tc.wantErr {
-					t.Fatalf("error: got %v, want %v", err, tc.wantErr)
-				}
+				require.ErrorIs(t, err, tc.wantErr)
 				return
 			}
 			if tc.wantErrSub != "" {
-				if err == nil {
-					t.Fatalf("expected error containing %q, got nil", tc.wantErrSub)
-				}
-				if !strings.Contains(err.Error(), tc.wantErrSub) {
-					t.Errorf("error %q does not contain %q", err.Error(), tc.wantErrSub)
-				}
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tc.wantErrSub)
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if gotFlags != tc.wantFlags {
-				t.Errorf("OpsFlags: got %+v, want %+v", gotFlags, tc.wantFlags)
-			}
-			if len(gotPos) != len(tc.wantPos) {
-				t.Fatalf("positionals: got %v, want %v", gotPos, tc.wantPos)
-			}
-			for i, w := range tc.wantPos {
-				if gotPos[i] != w {
-					t.Errorf("positionals[%d]: got %q, want %q", i, gotPos[i], w)
-				}
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantFlags, gotFlags)
+			assert.Equal(t, tc.wantPos, gotPos)
 		})
 	}
 }
 
 func TestParseOpsFlags_HelpOutput(t *testing.T) {
-	// Capture stderr from -h to verify usage text is printed.
-	origStderr := os.Stderr
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	os.Stderr = w
+	var buf bytes.Buffer
+	_, _, gotErr := ParseOpsFlags([]string{"-h"}, &buf)
 
-	_, _, gotErr := ParseOpsFlags([]string{"-h"})
+	require.ErrorIs(t, gotErr, ErrHelp)
 
-	w.Close()
-	os.Stderr = origStderr
-
-	captured, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	output := string(captured)
-
-	if gotErr != ErrHelp {
-		t.Fatalf("expected ErrHelp, got %v", gotErr)
-	}
-
+	output := buf.String()
 	for _, want := range []string{"-D", "-d", "-s", "-v"} {
-		if !strings.Contains(output, want) {
-			t.Errorf("help output does not contain %q", want)
-		}
+		assert.Contains(t, output, want)
 	}
 
 	// Verify unknown flag error includes the flag name.
-	_, _, unknownErr := ParseOpsFlags([]string{"--foobar"})
-	if unknownErr == nil {
-		t.Fatal("expected error for --foobar, got nil")
-	}
-	if !strings.Contains(unknownErr.Error(), "foobar") {
-		t.Errorf("error %q does not mention the unknown flag name 'foobar'", unknownErr.Error())
-	}
+	_, _, unknownErr := ParseOpsFlags([]string{"--foobar"}, &buf)
+	require.Error(t, unknownErr)
+	assert.ErrorContains(t, unknownErr, "foobar")
 }
 
 func TestParseOpsArgs(t *testing.T) {
@@ -270,34 +232,17 @@ func TestParseOpsArgs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := ParseOpsArgs(tc.input)
 			if tc.wantErrSub != "" {
-				if err == nil {
-					t.Fatalf("expected error containing %q, got nil", tc.wantErrSub)
-				}
-				if !strings.Contains(err.Error(), tc.wantErrSub) {
-					t.Errorf("error %q does not contain %q", err.Error(), tc.wantErrSub)
-				}
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tc.wantErrSub)
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if got.OpsEnv != tc.wantEnv {
-				t.Errorf("OpsEnv: got %q, want %q", got.OpsEnv, tc.wantEnv)
-			}
-			if got.OpsCommand != tc.wantCmd {
-				t.Errorf("OpsCommand: got %q, want %q", got.OpsCommand, tc.wantCmd)
-			}
-			if len(tc.wantArgs) == 0 && len(got.CommandArgs) == 0 {
-				return
-			}
-			if len(got.CommandArgs) != len(tc.wantArgs) {
-				t.Errorf("CommandArgs: got %v, want %v", got.CommandArgs, tc.wantArgs)
-				return
-			}
-			for i, a := range tc.wantArgs {
-				if got.CommandArgs[i] != a {
-					t.Errorf("CommandArgs[%d]: got %q, want %q", i, got.CommandArgs[i], a)
-				}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantEnv, got.OpsEnv)
+			assert.Equal(t, tc.wantCmd, got.OpsCommand)
+			if len(tc.wantArgs) == 0 {
+				assert.Empty(t, got.CommandArgs)
+			} else {
+				assert.Equal(t, tc.wantArgs, got.CommandArgs)
 			}
 		})
 	}

--- a/internal/opsfile_parser_test.go
+++ b/internal/opsfile_parser_test.go
@@ -4,8 +4,10 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseExamples_AllFilesParseWithoutError(t *testing.T) {
@@ -13,19 +15,13 @@ func TestParseExamples_AllFilesParseWithoutError(t *testing.T) {
 	examplesDir := filepath.Join(filepath.Dir(thisFile), "..", "examples")
 
 	files, err := filepath.Glob(filepath.Join(examplesDir, "Opsfile*"))
-	if err != nil {
-		t.Fatalf("globbing examples dir: %v", err)
-	}
-	if len(files) == 0 {
-		t.Fatal("no example Opsfiles found")
-	}
+	require.NoError(t, err, "globbing examples dir")
+	require.NotEmpty(t, files, "no example Opsfiles found")
 
 	for _, path := range files {
 		t.Run(filepath.Base(path), func(t *testing.T) {
 			_, _, err := ParseOpsFile(path)
-			if err != nil {
-				t.Errorf("ParseOpsFile(%q) returned error: %v", filepath.Base(path), err)
-			}
+			assert.NoError(t, err)
 		})
 	}
 }
@@ -34,12 +30,9 @@ func TestParseExamples_AllFilesParseWithoutError(t *testing.T) {
 func writeTempOpsfile(t *testing.T, content string) string {
 	t.Helper()
 	f, err := os.CreateTemp(t.TempDir(), "Opsfile*")
-	if err != nil {
-		t.Fatalf("creating temp file: %v", err)
-	}
-	if _, err := f.WriteString(content); err != nil {
-		t.Fatalf("writing temp file: %v", err)
-	}
+	require.NoError(t, err, "creating temp file")
+	_, err = f.WriteString(content)
+	require.NoError(t, err, "writing temp file")
 	f.Close()
 	return f.Name()
 }
@@ -54,9 +47,7 @@ func examplesOpsfile(t *testing.T) string {
 
 func TestParseOpsFile_Variables(t *testing.T) {
 	vars, _, err := ParseOpsFile(examplesOpsfile(t))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	cases := []struct{ name, want string }{
 		{"prod_AWS_ACCOUNT", "123456789012"},
@@ -64,21 +55,14 @@ func TestParseOpsFile_Variables(t *testing.T) {
 	}
 	for _, tc := range cases {
 		got, ok := vars[tc.name]
-		if !ok {
-			t.Errorf("variable %q not found", tc.name)
-			continue
-		}
-		if got != tc.want {
-			t.Errorf("variable %q: got %q, want %q", tc.name, got, tc.want)
-		}
+		require.True(t, ok, "variable %q not found", tc.name)
+		assert.Equal(t, tc.want, got, "variable %q", tc.name)
 	}
 }
 
 func TestParseOpsFile_NoComments(t *testing.T) {
 	vars, commands, err := ParseOpsFile(examplesOpsfile(t))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	for k, v := range vars {
 		if len(k) > 0 && k[0] == '#' {
@@ -98,96 +82,63 @@ func TestParseOpsFile_NoComments(t *testing.T) {
 
 func TestParseOpsFile_Commands(t *testing.T) {
 	_, commands, err := ParseOpsFile(examplesOpsfile(t))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	expectedCommands := []string{"tail-logs", "list-instance-ips", "show-profile"}
 	for _, name := range expectedCommands {
 		cmd, ok := commands[name]
-		if !ok {
-			t.Errorf("command %q not found", name)
-			continue
-		}
-		if cmd.Name != name {
-			t.Errorf("command Name field: got %q, want %q", cmd.Name, name)
-		}
+		require.True(t, ok, "command %q not found", name)
+		assert.Equal(t, name, cmd.Name, "command Name field")
 	}
 
-	if got := len(commands); got != len(expectedCommands) {
-		t.Errorf("expected %d commands, got %d", len(expectedCommands), got)
-	}
+	assert.Len(t, commands, len(expectedCommands))
 }
 
 func TestParseOpsFile_TailLogsEnvironments(t *testing.T) {
 	_, commands, err := ParseOpsFile(examplesOpsfile(t))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	cmd, ok := commands["tail-logs"]
-	if !ok {
-		t.Fatal("command 'tail-logs' not found")
-	}
+	require.True(t, ok, "command 'tail-logs' not found")
 
 	// Should have "default" and "local" environments
 	for _, env := range []string{"default", "local"} {
-		if _, ok := cmd.Environments[env]; !ok {
-			t.Errorf("environment %q not found in tail-logs", env)
-		}
+		assert.Contains(t, cmd.Environments, env, "environment %q not found in tail-logs", env)
 	}
 
 	// default environment: 4 backslash-continuation lines join into 1
 	defaultLines := cmd.Environments["default"]
-	if len(defaultLines) != 1 {
-		t.Errorf("tail-logs/default: expected 1 line, got %d: %v", len(defaultLines), defaultLines)
-	} else if want := "aws logs tail $(LOG_GROUP) --follow --since 10m --region $(AWS_REGION)"; defaultLines[0] != want {
-		t.Errorf("tail-logs/default line 0: got %q, want %q", defaultLines[0], want)
-	}
+	require.Len(t, defaultLines, 1, "tail-logs/default: expected 1 line")
+	assert.Equal(t, "aws logs tail $(LOG_GROUP) --follow --since 10m --region $(AWS_REGION)", defaultLines[0])
 
 	// local environment should have 1 shell line
 	localLines := cmd.Environments["local"]
-	if len(localLines) != 1 {
-		t.Errorf("tail-logs/local: expected 1 line, got %d: %v", len(localLines), localLines)
-	} else if want := "docker logs my-service --follow --tail 100"; localLines[0] != want {
-		t.Errorf("tail-logs/local line 0: got %q, want %q", localLines[0], want)
-	}
+	require.Len(t, localLines, 1, "tail-logs/local: expected 1 line")
+	assert.Equal(t, "docker logs my-service --follow --tail 100", localLines[0])
 }
 
 func TestParseOpsFile_ListInstanceIpsEnvironments(t *testing.T) {
 	_, commands, err := ParseOpsFile(examplesOpsfile(t))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	cmd, ok := commands["list-instance-ips"]
-	if !ok {
-		t.Fatal("command 'list-instance-ips' not found")
-	}
+	require.True(t, ok, "command 'list-instance-ips' not found")
 
 	for _, env := range []string{"prod", "preprod"} {
-		if _, ok := cmd.Environments[env]; !ok {
-			t.Errorf("environment %q not found in list-instance-ips", env)
-		}
+		assert.Contains(t, cmd.Environments, env, "environment %q not found in list-instance-ips", env)
 	}
 
 	// Both environments use backslash continuation — each produces 1 joined shell line.
 	prodLines := cmd.Environments["prod"]
-	if len(prodLines) != 1 {
-		t.Errorf("list-instance-ips/prod: expected 1 line, got %d: %v", len(prodLines), prodLines)
-	}
+	assert.Len(t, prodLines, 1, "list-instance-ips/prod: expected 1 line")
 
 	preprodLines := cmd.Environments["preprod"]
-	if len(preprodLines) != 1 {
-		t.Errorf("list-instance-ips/preprod: expected 1 line, got %d: %v", len(preprodLines), preprodLines)
-	}
+	assert.Len(t, preprodLines, 1, "list-instance-ips/preprod: expected 1 line")
 }
 
 func TestParseOpsFile_FileNotFound(t *testing.T) {
 	_, _, err := ParseOpsFile("/nonexistent/path/Opsfile")
-	if err == nil {
-		t.Error("expected error for missing file, got nil")
-	}
+	require.Error(t, err)
 }
 
 func TestExtractVariableValue(t *testing.T) {
@@ -216,13 +167,8 @@ func TestExtractVariableValue(t *testing.T) {
 
 	for _, tc := range okCases {
 		got, err := extractVariableValue(tc.raw)
-		if err != nil {
-			t.Errorf("extractVariableValue(%q) unexpected error: %v", tc.raw, err)
-			continue
-		}
-		if got != tc.want {
-			t.Errorf("extractVariableValue(%q) = %q, want %q", tc.raw, got, tc.want)
-		}
+		require.NoError(t, err, "extractVariableValue(%q) unexpected error", tc.raw)
+		assert.Equal(t, tc.want, got, "extractVariableValue(%q)", tc.raw)
 	}
 
 	errorCases := []string{
@@ -231,9 +177,7 @@ func TestExtractVariableValue(t *testing.T) {
 	}
 	for _, raw := range errorCases {
 		_, err := extractVariableValue(raw)
-		if err == nil {
-			t.Errorf("extractVariableValue(%q) expected error, got nil", raw)
-		}
+		assert.Error(t, err, "extractVariableValue(%q) expected error", raw)
 	}
 }
 
@@ -249,9 +193,7 @@ my-cmd:
         aws something
 `
 	vars, _, err := ParseOpsFile(writeTempOpsfile(t, content))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	cases := []struct{ name, want string }{
 		{"PLAIN", "123"},
 		{"TABS", "456"},
@@ -259,9 +201,7 @@ my-cmd:
 		{"NOSPACE", "val#notcomment"},
 	}
 	for _, tc := range cases {
-		if got := vars[tc.name]; got != tc.want {
-			t.Errorf("variable %q: got %q, want %q", tc.name, got, tc.want)
-		}
+		assert.Equal(t, tc.want, vars[tc.name], "variable %q", tc.name)
 	}
 }
 
@@ -274,33 +214,21 @@ my-cmd:
         aws something
 `
 	_, _, err := ParseOpsFile(writeTempOpsfile(t, content))
-	if err == nil {
-		t.Fatal("expected error for unclosed quote, got nil")
-	}
-	if !strings.Contains(err.Error(), "unclosed") {
-		t.Errorf("error should mention 'unclosed', got: %v", err)
-	}
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "unclosed")
 }
 
 func TestParseOpsFile_EmptyFile(t *testing.T) {
 	_, _, err := ParseOpsFile(writeTempOpsfile(t, ""))
-	if err == nil {
-		t.Fatal("expected error for empty file, got nil")
-	}
-	if !strings.Contains(err.Error(), "empty") {
-		t.Errorf("error should mention 'empty', got: %v", err)
-	}
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "empty")
 }
 
 func TestParseOpsFile_OnlyComments(t *testing.T) {
 	content := "# just a comment\n# another comment\n"
 	_, _, err := ParseOpsFile(writeTempOpsfile(t, content))
-	if err == nil {
-		t.Fatal("expected error for comment-only file, got nil")
-	}
-	if !strings.Contains(err.Error(), "empty") {
-		t.Errorf("error should mention 'empty', got: %v", err)
-	}
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "empty")
 }
 
 func TestParseOpsFile_DuplicateCommand(t *testing.T) {
@@ -314,12 +242,8 @@ my-cmd:
         aws ecs something
 `
 	_, _, err := ParseOpsFile(writeTempOpsfile(t, content))
-	if err == nil {
-		t.Fatal("expected error for duplicate command, got nil")
-	}
-	if !strings.Contains(err.Error(), "duplicate") {
-		t.Errorf("error should mention 'duplicate', got: %v", err)
-	}
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "duplicate")
 }
 
 func TestParseOpsFile_VariableMissingName(t *testing.T) {
@@ -331,12 +255,8 @@ my-cmd:
         aws something
 `
 	_, _, err := ParseOpsFile(writeTempOpsfile(t, content))
-	if err == nil {
-		t.Fatal("expected error for variable with missing name, got nil")
-	}
-	if !strings.Contains(err.Error(), "missing name") {
-		t.Errorf("error should mention 'missing name', got: %v", err)
-	}
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "missing name")
 }
 
 func TestParseOpsFile_BackslashContinuation(t *testing.T) {
@@ -347,17 +267,10 @@ my-cmd:
             --log-group /my/group
 `
 	_, commands, err := ParseOpsFile(writeTempOpsfile(t, content))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	lines := commands["my-cmd"].Environments["prod"]
-	if len(lines) != 1 {
-		t.Fatalf("expected 1 shell line, got %d: %v", len(lines), lines)
-	}
-	want := "aws cloudwatch logs --log-group /my/group"
-	if lines[0] != want {
-		t.Errorf("got %q, want %q", lines[0], want)
-	}
+	require.Len(t, lines, 1)
+	assert.Equal(t, "aws cloudwatch logs --log-group /my/group", lines[0])
 }
 
 func TestParseOpsFile_BackslashContinuationChain(t *testing.T) {
@@ -369,17 +282,10 @@ my-cmd:
             --tail
 `
 	_, commands, err := ParseOpsFile(writeTempOpsfile(t, content))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	lines := commands["my-cmd"].Environments["prod"]
-	if len(lines) != 1 {
-		t.Fatalf("expected 1 shell line, got %d: %v", len(lines), lines)
-	}
-	want := "aws cloudwatch logs --log-group /my/group --tail"
-	if lines[0] != want {
-		t.Errorf("got %q, want %q", lines[0], want)
-	}
+	require.Len(t, lines, 1)
+	assert.Equal(t, "aws cloudwatch logs --log-group /my/group --tail", lines[0])
 }
 
 func TestParseOpsFile_BackslashSpaceBeforeSlash(t *testing.T) {
@@ -390,17 +296,10 @@ my-cmd:
             --tail
 `
 	_, commands, err := ParseOpsFile(writeTempOpsfile(t, content))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	lines := commands["my-cmd"].Environments["prod"]
-	if len(lines) != 1 {
-		t.Fatalf("expected 1 shell line, got %d: %v", len(lines), lines)
-	}
-	want := "aws logs --tail"
-	if lines[0] != want {
-		t.Errorf("got %q, want %q", lines[0], want)
-	}
+	require.Len(t, lines, 1)
+	assert.Equal(t, "aws logs --tail", lines[0])
 }
 
 func TestParseOpsFile_IndentContinuation(t *testing.T) {
@@ -411,17 +310,10 @@ my-cmd:
             --log-group /my/group
 `
 	_, commands, err := ParseOpsFile(writeTempOpsfile(t, content))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	lines := commands["my-cmd"].Environments["prod"]
-	if len(lines) != 1 {
-		t.Fatalf("expected 1 shell line, got %d: %v", len(lines), lines)
-	}
-	want := "aws cloudwatch logs --log-group /my/group"
-	if lines[0] != want {
-		t.Errorf("got %q, want %q", lines[0], want)
-	}
+	require.Len(t, lines, 1)
+	assert.Equal(t, "aws cloudwatch logs --log-group /my/group", lines[0])
 }
 
 func TestParseOpsFile_IndentContinuationChain(t *testing.T) {
@@ -433,17 +325,10 @@ my-cmd:
             --tail
 `
 	_, commands, err := ParseOpsFile(writeTempOpsfile(t, content))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	lines := commands["my-cmd"].Environments["prod"]
-	if len(lines) != 1 {
-		t.Fatalf("expected 1 shell line, got %d: %v", len(lines), lines)
-	}
-	want := "aws cloudwatch logs --log-group /my/group --tail"
-	if lines[0] != want {
-		t.Errorf("got %q, want %q", lines[0], want)
-	}
+	require.Len(t, lines, 1)
+	assert.Equal(t, "aws cloudwatch logs --log-group /my/group --tail", lines[0])
 }
 
 func TestParseOpsFile_IndentNewCommandAfterContinuation(t *testing.T) {
@@ -455,31 +340,19 @@ my-cmd:
         echo done
 `
 	_, commands, err := ParseOpsFile(writeTempOpsfile(t, content))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	lines := commands["my-cmd"].Environments["prod"]
-	if len(lines) != 2 {
-		t.Fatalf("expected 2 shell lines, got %d: %v", len(lines), lines)
-	}
-	if lines[0] != "aws cloudwatch logs --log-group /my/group" {
-		t.Errorf("line 0: got %q", lines[0])
-	}
-	if lines[1] != "echo done" {
-		t.Errorf("line 1: got %q", lines[1])
-	}
+	require.Len(t, lines, 2)
+	assert.Equal(t, "aws cloudwatch logs --log-group /my/group", lines[0])
+	assert.Equal(t, "echo done", lines[1])
 }
 
 func TestParseOpsFile_VariableWhitespaceOnlyValue(t *testing.T) {
 	content := "VAR=   \n\nmy-cmd:\n    prod:\n        echo hello\n"
 	vars, _, err := ParseOpsFile(writeTempOpsfile(t, content))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	// TrimSpace on the value after "=" yields empty string.
-	if got := vars["VAR"]; got != "" {
-		t.Errorf("VAR: got %q, want %q", got, "")
-	}
+	assert.Equal(t, "", vars["VAR"])
 }
 
 func TestParseOpsFile_VariableEmptyUnquotedValue(t *testing.T) {
@@ -491,12 +364,8 @@ my-cmd:
         echo hello
 `
 	vars, _, err := ParseOpsFile(writeTempOpsfile(t, content))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got := vars["VAR"]; got != "" {
-		t.Errorf("VAR: got %q, want %q", got, "")
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "", vars["VAR"])
 }
 
 func TestParseOpsFile_MultipleEnvironments(t *testing.T) {
@@ -512,20 +381,12 @@ my-cmd:
         echo default
 `
 	_, commands, err := ParseOpsFile(writeTempOpsfile(t, content))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	cmd := commands["my-cmd"]
 	for _, env := range []string{"prod", "preprod", "local", "default"} {
 		lines, ok := cmd.Environments[env]
-		if !ok {
-			t.Errorf("environment %q not found", env)
-			continue
-		}
-		want := "echo " + env
-		if len(lines) != 1 || lines[0] != want {
-			t.Errorf("env %q: got %v, want [%q]", env, lines, want)
-		}
+		require.True(t, ok, "environment %q not found", env)
+		assert.Equal(t, []string{"echo " + env}, lines, "env %q", env)
 	}
 }
 
@@ -538,39 +399,23 @@ my-cmd:
             --since 10m
 `
 	_, commands, err := ParseOpsFile(writeTempOpsfile(t, content))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	lines := commands["my-cmd"].Environments["prod"]
 	// Backslash joins first two into one line; the third line at same indent
 	// is NOT deeper than the flushed continuation, so it's a separate shell line.
-	if len(lines) != 2 {
-		t.Fatalf("expected 2 shell lines, got %d: %v", len(lines), lines)
-	}
-	if lines[0] != "aws logs tail --follow" {
-		t.Errorf("line 0: got %q, want %q", lines[0], "aws logs tail --follow")
-	}
-	if lines[1] != "--since 10m" {
-		t.Errorf("line 1: got %q, want %q", lines[1], "--since 10m")
-	}
+	require.Len(t, lines, 2)
+	assert.Equal(t, "aws logs tail --follow", lines[0])
+	assert.Equal(t, "--since 10m", lines[1])
 }
 
 func TestParseOpsFile_TabIndentedShellLines(t *testing.T) {
 	content := "my-cmd:\n\tprod:\n\t\techo hello\n\t\techo world\n"
 	_, commands, err := ParseOpsFile(writeTempOpsfile(t, content))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	lines := commands["my-cmd"].Environments["prod"]
-	if len(lines) != 2 {
-		t.Fatalf("expected 2 shell lines, got %d: %v", len(lines), lines)
-	}
-	if lines[0] != "echo hello" {
-		t.Errorf("line 0: got %q, want %q", lines[0], "echo hello")
-	}
-	if lines[1] != "echo world" {
-		t.Errorf("line 1: got %q, want %q", lines[1], "echo world")
-	}
+	require.Len(t, lines, 2)
+	assert.Equal(t, "echo hello", lines[0])
+	assert.Equal(t, "echo world", lines[1])
 }
 
 func TestParseOpsFile_CommandHeaderTrailingWhitespace(t *testing.T) {
@@ -578,24 +423,16 @@ func TestParseOpsFile_CommandHeaderTrailingWhitespace(t *testing.T) {
 	// Note: TrimSpace strips trailing whitespace, so "my-cmd:  " -> "my-cmd:"
 	content := "my-cmd:  \n    prod:\n        echo hello\n"
 	_, commands, err := ParseOpsFile(writeTempOpsfile(t, content))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if _, ok := commands["my-cmd"]; !ok {
-		t.Error("command 'my-cmd' not found")
-	}
+	require.NoError(t, err)
+	assert.Contains(t, commands, "my-cmd")
 }
 
 func TestParseOpsFile_EnvHeaderTrailingWhitespace(t *testing.T) {
 	// Trailing whitespace on env header line.
 	content := "my-cmd:\n    prod:  \n        echo hello\n"
 	_, commands, err := ParseOpsFile(writeTempOpsfile(t, content))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if _, ok := commands["my-cmd"].Environments["prod"]; !ok {
-		t.Error("environment 'prod' not found")
-	}
+	require.NoError(t, err)
+	assert.Contains(t, commands["my-cmd"].Environments, "prod")
 }
 
 func TestParseOpsFile_VariableValueLeadingWhitespace(t *testing.T) {
@@ -607,13 +444,9 @@ my-cmd:
         echo hello
 `
 	vars, _, err := ParseOpsFile(writeTempOpsfile(t, content))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	// parseVariable does TrimSpace on the value after "=", so "  value" -> "value"
-	if got := vars["VAR"]; got != "value" {
-		t.Errorf("VAR: got %q, want %q", got, "value")
-	}
+	assert.Equal(t, "value", vars["VAR"])
 }
 
 func TestParseOpsFile_LineNumberInParseError(t *testing.T) {
@@ -626,13 +459,9 @@ my-cmd:
         echo hello
 `
 	_, _, err := ParseOpsFile(writeTempOpsfile(t, content))
-	if err == nil {
-		t.Fatal("expected error for unclosed quote, got nil")
-	}
+	require.Error(t, err)
 	// The unclosed quote is on line 3 (blank line 1, GOOD=fine line 2, BAD=... line 3).
-	if !strings.Contains(err.Error(), "line 3") {
-		t.Errorf("error should include line number, got: %v", err)
-	}
+	assert.ErrorContains(t, err, "line 3")
 }
 
 func TestParseOpsFile_BackslashTrailingEOF(t *testing.T) {
@@ -641,16 +470,9 @@ my-cmd:
     prod:
         aws cloudwatch logs \`
 	_, commands, err := ParseOpsFile(writeTempOpsfile(t, content))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	lines := commands["my-cmd"].Environments["prod"]
-	if len(lines) != 1 {
-		t.Fatalf("expected 1 shell line, got %d: %v", len(lines), lines)
-	}
+	require.Len(t, lines, 1)
 	// The trailing \ is stripped; what remains is the fragment before it.
-	want := "aws cloudwatch logs "
-	if lines[0] != want {
-		t.Errorf("got %q, want %q", lines[0], want)
-	}
+	assert.Equal(t, "aws cloudwatch logs ", lines[0])
 }

--- a/internal/version_test.go
+++ b/internal/version_test.go
@@ -3,19 +3,18 @@ package internal
 import (
 	"regexp"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // semverRe matches a valid semver string (e.g. "1.2.3" or "1.2.3-beta.1").
 var semverRe = regexp.MustCompile(`^\d+\.\d+\.\d+(-[\w.]+)?$`)
 
 func TestVersion_IsNonEmpty(t *testing.T) {
-	if Version == "" {
-		t.Fatal("Version must not be empty")
-	}
+	require.NotEmpty(t, Version, "Version must not be empty")
 }
 
 func TestVersion_IsSemver(t *testing.T) {
-	if !semverRe.MatchString(Version) {
-		t.Errorf("Version %q is not a valid semver string", Version)
-	}
+	assert.Regexp(t, semverRe, Version, "Version %q is not a valid semver string", Version)
 }


### PR DESCRIPTION
## Key Changes

- Add `github.com/stretchr/testify` dependency
- Migrate all `internal/*_test.go` and `cmd/ops/main_test.go` files from raw stdlib assertions to `testify/assert` and `testify/require`
- `require` used for guard conditions where failure would make subsequent assertions meaningless
- `assert` used for result validation where the test can continue on failure
- Refactor `ParseOpsFlags` to accept an `io.Writer` for usage output, eliminating the fragile `os.Stderr` FD redirect in `TestParseOpsFlags_HelpOutput`
- Slice/length comparisons replaced with `assert.Equal` and `require.Len`
- Error substring checks replaced with `assert.ErrorContains`
- All test helpers audited for `t.Helper()`

## Why do we need this?

Completes the Issue #9 code quality pass. testify reduces assertion boilerplate, produces clearer failure diffs, and the `require` vs `assert` distinction makes test control flow explicit. The `ParseOpsFlags` io.Writer refactor also removes a process-wide side effect from the test suite.

## New modules or other dependencies introduced

- `github.com/stretchr/testify` — the most widely used Go test assertion library, actively maintained

## How was this tested?

`make lint`, `make test`, and `make build` all pass in an isolated git worktree. No test cases were removed or weakened. Coverage is unchanged.