### PR TITLE
feat: add Homebrew tap install support (Issue#10)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
           go-version-file: go.mod
       - name: Run tests
         run: make test
+      - name: Run install smoke tests
+        run: make test-install
 
   release:
     name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,3 +86,14 @@ jobs:
           name: ${{ steps.version.outputs.version }}
           body: ${{ steps.changelog.outputs.content }}
           files: bin/ops_*
+
+      - name: Update Homebrew formula
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          URL="https://github.com/seanseannery/opsfile/archive/refs/tags/${VERSION}.tar.gz"
+          SHA256=$(curl -fsSL "${URL}" | sha256sum | awk '{print $1}')
+          sed -i "s|url \".*\"|url \"${URL}\"|" Formula/opsfile.rb
+          sed -i "s|sha256 \".*\"|sha256 \"${SHA256}\"|" Formula/opsfile.rb
+          git add Formula/opsfile.rb
+          git commit -m "chore: update Homebrew formula to ${VERSION}"
+          git push origin main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@
     ├────── workflows/        GitHub Actions workflows definitions (release, PR checks) and cliff.toml changelog config
     ├── .githooks/            Local git hooks: pre-push (lint+test), commit-msg (conventional commit format)
     │
+    ├── Formula/              Homebrew tap formula — auto-updated by release.yml on each release
     ├── go.mod                Module declaration (sean_seannery/opsfile, Go 1.25+, no external deps)
     ├── AGENTS.md             This file — source of truth for agentic context
     ├── CLAUDE.md             Links to AGENTS.md (Claude does not natively support AGENTS.md)

--- a/Formula/opsfile.rb
+++ b/Formula/opsfile.rb
@@ -1,0 +1,22 @@
+class Opsfile < Formula
+  desc "Like make/Makefile but for live operations commands"
+  homepage "https://github.com/seanseannery/opsfile"
+  url "https://github.com/seanseannery/opsfile/archive/refs/tags/v0.0.0.tar.gz"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X sean_seannery/opsfile/internal.Version=#{version}
+      -X sean_seannery/opsfile/internal.Commit=none
+    ]
+    system "go", "build", *std_go_args(output: bin/"ops", ldflags: ldflags), "./cmd/ops"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/ops --version 2>&1")
+  end
+end

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ deps:
 test:
 	go test -v ./...
 
+## test-install: run end-to-end install smoke tests (curl and brew)
+test-install:
+	bash install/install_test.sh
+
 ## lint: check formatting (gofmt) and run static analysis (go vet)
 lint:
 	@echo "--- gofmt ---"; \

--- a/README.md
+++ b/README.md
@@ -6,12 +6,20 @@
 
 ## Installation
 
-  ### MacOS / Linux
+  ### Homebrew (MacOS / Linux)
+
+  ```bash
+  brew tap seanseannery/opsfile https://github.com/seanseannery/opsfile
+  brew install seanseannery/opsfile
+  ```
+  After tapping, `brew upgrade seanseannery/opsfile` keeps `ops` up to date.
+
+  ### curl (MacOS / Linux)
 
   ```bash
   curl -fsSL https://raw.githubusercontent.com/seanseannery/opsfile/main/install/install.sh | bash
   ```
-  Paste this in your terminal. The script detects your OS, downloads the correct binary from the [latest GitHub release](https://github.com/seanseannery/opsfile/releases/latest), and installs to `/usr/local/bin/ops`
+  Detects your OS, downloads the correct binary from the [latest GitHub release](https://github.com/seanseannery/opsfile/releases/latest), and installs to `/usr/local/bin/ops`.
 
   ### Windows
   Download `ops.exe` directly from the [releases page](https://github.com/seanseannery/opsfile/releases/latest).

--- a/install/install.sh
+++ b/install/install.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 REPO="seanseannery/opsfile"
 BINARY="ops"
-INSTALL_DIR="/usr/local/bin"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 
 # ── OS detection ────────────────────────────────────────────────────────────
 

--- a/install/install_test.sh
+++ b/install/install_test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# install_test.sh — end-to-end smoke test for both install methods.
+# Requires network access and a published GitHub release.
+# Brew cleanup is performed automatically on exit.
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+BREW_TAPPED=false
+BREW_INSTALLED=false
+
+CURL_INSTALL_PATH="/usr/local/bin/ops"
+
+pass() { echo "  PASS: $1"; ((PASS++)) || true; }
+fail() { echo "  FAIL: $1" >&2; ((FAIL++)) || true; }
+
+cleanup_brew() {
+  echo ""
+  echo "=== cleanup ==="
+  if [ "$BREW_INSTALLED" = true ]; then
+    brew uninstall opsfile 2>/dev/null && echo "  brew uninstall: done" || echo "  brew uninstall: skipped"
+  fi
+  if [ "$BREW_TAPPED" = true ]; then
+    brew untap seanseannery/opsfile 2>/dev/null && echo "  brew untap: done" || echo "  brew untap: skipped"
+  fi
+}
+trap cleanup_brew EXIT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── curl install test ─────────────────────────────────────────────────────────
+
+echo ""
+echo "=== curl install test ==="
+
+if bash "$SCRIPT_DIR/install.sh"; then
+  if ops --version > /dev/null 2>&1; then
+    pass "ops binary installed and responds to --version"
+  else
+    fail "ops binary installed but --version failed"
+  fi
+else
+  fail "curl install script exited non-zero"
+fi
+
+# Remove curl-installed binary before brew test to avoid path conflicts.
+if [ -f "$CURL_INSTALL_PATH" ]; then
+  rm -f "$CURL_INSTALL_PATH" 2>/dev/null || sudo rm -f "$CURL_INSTALL_PATH"
+  pass "curl cleanup: removed $CURL_INSTALL_PATH"
+fi
+
+# ── brew install test ─────────────────────────────────────────────────────────
+
+echo ""
+echo "=== brew install test ==="
+
+if ! command -v brew > /dev/null 2>&1; then
+  echo "  SKIP: brew not found"
+else
+  if brew tap seanseannery/opsfile https://github.com/seanseannery/opsfile; then
+    BREW_TAPPED=true
+    if brew install seanseannery/opsfile; then
+      BREW_INSTALLED=true
+      BREW_OPS="$(brew --prefix)/bin/ops"
+      if "$BREW_OPS" --version > /dev/null 2>&1; then
+        pass "ops installed via brew and responds to --version"
+      else
+        fail "ops installed via brew but --version failed"
+      fi
+    else
+      fail "brew install seanseannery/opsfile failed"
+    fi
+  else
+    fail "brew tap seanseannery/opsfile failed"
+  fi
+fi
+
+# ── summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/install/install_test.sh
+++ b/install/install_test.sh
@@ -11,14 +11,18 @@ FAIL=0
 BREW_TAPPED=false
 BREW_INSTALLED=false
 
-CURL_INSTALL_PATH="/usr/local/bin/ops"
+CURL_TMP_DIR=""
 
 pass() { echo "  PASS: $1"; ((PASS++)) || true; }
 fail() { echo "  FAIL: $1" >&2; ((FAIL++)) || true; }
 
-cleanup_brew() {
+cleanup() {
   echo ""
   echo "=== cleanup ==="
+  if [ -n "$CURL_TMP_DIR" ] && [ -d "$CURL_TMP_DIR" ]; then
+    rm -rf "$CURL_TMP_DIR"
+    echo "  curl tmp dir removed"
+  fi
   if [ "$BREW_INSTALLED" = true ]; then
     brew uninstall opsfile 2>/dev/null && echo "  brew uninstall: done" || echo "  brew uninstall: skipped"
   fi
@@ -26,7 +30,7 @@ cleanup_brew() {
     brew untap seanseannery/opsfile 2>/dev/null && echo "  brew untap: done" || echo "  brew untap: skipped"
   fi
 }
-trap cleanup_brew EXIT
+trap cleanup EXIT
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -35,20 +39,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 echo ""
 echo "=== curl install test ==="
 
-if bash "$SCRIPT_DIR/install.sh"; then
-  if ops --version > /dev/null 2>&1; then
+CURL_TMP_DIR="$(mktemp -d)"
+if INSTALL_DIR="$CURL_TMP_DIR" bash "$SCRIPT_DIR/install.sh"; then
+  if "$CURL_TMP_DIR/ops" --version > /dev/null 2>&1; then
     pass "ops binary installed and responds to --version"
   else
     fail "ops binary installed but --version failed"
   fi
 else
   fail "curl install script exited non-zero"
-fi
-
-# Remove curl-installed binary before brew test to avoid path conflicts.
-if [ -f "$CURL_INSTALL_PATH" ]; then
-  rm -f "$CURL_INSTALL_PATH" 2>/dev/null || sudo rm -f "$CURL_INSTALL_PATH"
-  pass "curl cleanup: removed $CURL_INSTALL_PATH"
 fi
 
 # ── brew install test ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Key Changes

- Add `Formula/opsfile.rb` — a Homebrew formula that builds `ops` from source using `go build` with version/commit ldflags
- Update `install/install.sh` to respect an `INSTALL_DIR` env var override (falls back to `/usr/local/bin`)
- Add `install/install_test.sh` — end-to-end smoke test for both the curl and brew install paths, with automatic cleanup on exit
- Update `.github/workflows/release.yml` — new step after each release to compute the source tarball SHA256 and commit an updated formula to main
- Update `README.md` — Homebrew install section added as the primary install method
- Update `AGENTS.md` — directory structure updated to include `Formula/`

## Why do we need this?

Closes #10. Homebrew is the most common package manager for macOS developers. This adds first-class `brew` support using a custom tap pointed directly at this repo, avoiding the need for a separate `homebrew-opsfile` repository.

Install UX after merge:
```bash
brew tap seanseannery/opsfile https://github.com/seanseannery/opsfile
brew install seanseannery/opsfile
```
Upgrades work via `brew upgrade seanseannery/opsfile`.

## New modules or other dependencies introduced

None. The formula uses `go` (already a build dependency) and no new Go packages.

## How was this tested?

- `install/install_test.sh` was run locally:
  - **curl install**: PASSED — binary installed to a temp dir, `ops --version` verified, temp dir cleaned up
  - **brew install**: expected to FAIL until this PR is merged to main (Homebrew taps the remote `main` branch; the formula doesn't exist there yet). Will be verified post-merge.
- `install.sh` INSTALL_DIR override manually verified by inspecting the subshell environment variable behaviour