### PR TITLE
fix: bootstrap Homebrew formula and correct brew install command

### DIFF
--- a/Formula/opsfile.rb
+++ b/Formula/opsfile.rb
@@ -1,8 +1,8 @@
 class Opsfile < Formula
   desc "Like make/Makefile but for live operations commands"
   homepage "https://github.com/seanseannery/opsfile"
-  url "https://github.com/seanseannery/opsfile/archive/refs/tags/v0.0.0.tar.gz"
-  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+  url "https://github.com/seanseannery/opsfile/archive/refs/tags/v0.8.1.tar.gz"
+  sha256 "ba15ebb200b8c9f82839c90c204ee2bf82bb1fdc1840335b10a8edc4f557eaab"
   license "MIT"
 
   depends_on "go" => :build

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
   ```bash
   brew tap seanseannery/opsfile https://github.com/seanseannery/opsfile
-  brew install seanseannery/opsfile
+  brew install seanseannery/opsfile/opsfile
   ```
-  After tapping, `brew upgrade seanseannery/opsfile` keeps `ops` up to date.
+  After tapping, `brew upgrade seanseannery/opsfile/opsfile` keeps `ops` up to date.
 
   ### curl (MacOS / Linux)
 

--- a/install/install_test.sh
+++ b/install/install_test.sh
@@ -24,7 +24,7 @@ cleanup() {
     echo "  curl tmp dir removed"
   fi
   if [ "$BREW_INSTALLED" = true ]; then
-    brew uninstall opsfile 2>/dev/null && echo "  brew uninstall: done" || echo "  brew uninstall: skipped"
+    brew uninstall seanseannery/opsfile/opsfile 2>/dev/null && echo "  brew uninstall: done" || echo "  brew uninstall: skipped"
   fi
   if [ "$BREW_TAPPED" = true ]; then
     brew untap seanseannery/opsfile 2>/dev/null && echo "  brew untap: done" || echo "  brew untap: skipped"
@@ -60,7 +60,7 @@ if ! command -v brew > /dev/null 2>&1; then
 else
   if brew tap seanseannery/opsfile https://github.com/seanseannery/opsfile; then
     BREW_TAPPED=true
-    if brew install seanseannery/opsfile; then
+    if brew install seanseannery/opsfile/opsfile; then
       BREW_INSTALLED=true
       BREW_OPS="$(brew --prefix)/bin/ops"
       if "$BREW_OPS" --version > /dev/null 2>&1; then


### PR DESCRIPTION
## Key Changes

- Update `Formula/opsfile.rb` with the correct `v0.8.1` tarball URL and SHA256 (was placeholder `v0.0.0`)
- Fix `brew install` command from `seanseannery/opsfile` to `seanseannery/opsfile/opsfile` (Homebrew requires the full 3-part tap/formula path)
- Update `README.md` and `install/install_test.sh` with the corrected install and upgrade commands

## Why do we need this?

The formula was added with placeholder values in #16. Without a real URL/SHA256, `brew install` fails immediately. Additionally, testing revealed Homebrew does not support the 2-part shorthand for custom tap installs — the full `user/tap/formula` form is required.

## New modules or other dependencies introduced

None.

## How was this tested?

`make test-install` was run locally after the fix was committed and pushed. Both the curl and brew install paths pass, with brew correctly tapping the repo, building `ops` from source, and responding to `--version`.