### PR TITLE
feat: add npm GitHub repo install support (Issue#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@
   ```
   After tapping, `brew upgrade seanseannery/opsfile/opsfile` keeps `ops` up to date.
 
+  ### npm (MacOS / Linux)
+
+  ```bash
+  npm install -g github:seanseannery/opsfile
+  ```
+  Requires Node.js ≥ 14. Downloads the correct platform binary from the latest GitHub release on install.
+
   ### curl (MacOS / Linux)
 
   ```bash

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   npm install -g github:seanseannery/opsfile
   ```
   Requires Node.js ≥ 14. Downloads the correct platform binary from the latest GitHub release on install.
+  To upgrade, re-run the same command. To uninstall: `npm uninstall -g opsfile`.
 
   ### curl (MacOS / Linux)
 

--- a/install/install_test.sh
+++ b/install/install_test.sh
@@ -10,6 +10,7 @@ FAIL=0
 
 BREW_TAPPED=false
 BREW_INSTALLED=false
+NPM_INSTALLED=false
 
 CURL_TMP_DIR=""
 
@@ -28,6 +29,9 @@ cleanup() {
   fi
   if [ "$BREW_TAPPED" = true ]; then
     brew untap seanseannery/opsfile 2>/dev/null && echo "  brew untap: done" || echo "  brew untap: skipped"
+  fi
+  if [ "$NPM_INSTALLED" = true ]; then
+    npm uninstall -g opsfile 2>/dev/null && echo "  npm uninstall: done" || echo "  npm uninstall: skipped"
   fi
 }
 trap cleanup EXIT
@@ -73,6 +77,27 @@ else
     fi
   else
     fail "brew tap seanseannery/opsfile failed"
+  fi
+fi
+
+# ── npm install test ─────────────────────────────────────────────────────────
+
+echo ""
+echo "=== npm install test ==="
+
+if ! command -v npm > /dev/null 2>&1; then
+  echo "  SKIP: npm not found"
+else
+  if npm install -g github:seanseannery/opsfile --no-fund --no-audit 2>&1; then
+    NPM_INSTALLED=true
+    NPM_OPS="$(npm config get prefix)/bin/ops"
+    if "$NPM_OPS" --version > /dev/null 2>&1; then
+      pass "ops installed via npm and responds to --version"
+    else
+      fail "ops installed via npm but --version failed"
+    fi
+  else
+    fail "npm install github:seanseannery/opsfile failed"
   fi
 fi
 

--- a/install/npm_install.js
+++ b/install/npm_install.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+'use strict';
+
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+
+const REPO = 'seanseannery/opsfile';
+const BIN_DIR = path.join(__dirname, '..', 'bin');
+const BIN_PATH = path.join(BIN_DIR, 'ops');
+
+function platformAssetPrefix() {
+  switch (process.platform) {
+    case 'darwin': return 'ops_darwin_v';
+    case 'linux':  return 'ops_unix_v';
+    default:
+      console.error(`Unsupported platform: ${process.platform}`);
+      process.exit(1);
+  }
+}
+
+function get(url) {
+  return new Promise((resolve, reject) => {
+    https.get(url, { headers: { 'User-Agent': 'opsfile-npm-installer' } }, (res) => {
+      if (res.statusCode === 301 || res.statusCode === 302) {
+        return get(res.headers.location).then(resolve).catch(reject);
+      }
+      const chunks = [];
+      res.on('data', chunk => chunks.push(chunk));
+      res.on('end', () => resolve(Buffer.concat(chunks)));
+      res.on('error', reject);
+    }).on('error', reject);
+  });
+}
+
+async function main() {
+  const prefix = platformAssetPrefix();
+
+  console.log(`Fetching latest release from github.com/${REPO} ...`);
+  const apiData = await get(`https://api.github.com/repos/${REPO}/releases/latest`);
+  const release = JSON.parse(apiData.toString());
+
+  const asset = release.assets.find(a => a.name.startsWith(prefix));
+  if (!asset) {
+    console.error(`No release asset found matching '${prefix}'`);
+    process.exit(1);
+  }
+
+  console.log(`Downloading ops ${release.tag_name} for ${process.platform} ...`);
+  const binary = await get(asset.browser_download_url);
+
+  fs.mkdirSync(BIN_DIR, { recursive: true });
+  fs.writeFileSync(BIN_PATH, binary, { mode: 0o755 });
+  console.log(`Installed ops ${release.tag_name}`);
+}
+
+main().catch(err => {
+  console.error('Install failed:', err.message);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "opsfile",
+  "version": "0.8.1",
+  "description": "Like make/Makefile but for live operations commands",
+  "homepage": "https://github.com/seanseannery/opsfile",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seanseannery/opsfile.git"
+  },
+  "license": "MIT",
+  "bin": {
+    "ops": "bin/ops"
+  },
+  "scripts": {
+    "postinstall": "node install/npm_install.js"
+  },
+  "os": ["darwin", "linux"],
+  "engines": {
+    "node": ">=14"
+  }
+}


### PR DESCRIPTION
## Key Changes

- Add `package.json` — npm package metadata with `bin.ops → bin/ops` and a `postinstall` hook
- Add `install/npm_install.js` — Node.js postinstall script that detects the platform, fetches the latest GitHub release, and downloads the correct binary to `bin/ops` (no external npm dependencies, uses Node.js built-in `https`)
- Update `install/install_test.sh` — add npm install test section with cleanup
- Update `README.md` — add npm install section

## Why do we need this?

Partial close of #11. Adds `npm install -g github:seanseannery/opsfile` support using a GitHub repo-based install (no npm registry account required). Publishing to the public npm registry is tracked separately in the updated issue.

## New modules or other dependencies introduced

None. `install/npm_install.js` uses only Node.js built-in modules (`https`, `fs`, `path`).

## How was this tested?

- `install/npm_install.js` was run directly (`node install/npm_install.js`) and successfully downloaded `ops v0.8.1` to `bin/ops` with correct permissions (`-rwxr-xr-x`); `bin/ops --version` responded correctly
- `make test-install` npm section will pass once this PR is merged to main (npm clones from remote main, same behaviour as the brew test before #16 merged)