### PR TITLE
feat: add GitHub Pages HTML landing page (Issue#5)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,33 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths: ['site/**']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@
     ├── .githooks/            Local git hooks: pre-push (lint+test), commit-msg (conventional commit format)
     │
     ├── Formula/              Homebrew tap formula — auto-updated by release.yml on each release
+    ├── site/                 GitHub Pages static landing page (HTML + CSS) — deployed by pages.yml
     ├── go.mod                Module declaration (sean_seannery/opsfile, Go 1.25+, no external deps)
     ├── AGENTS.md             This file — source of truth for agentic context
     ├── CLAUDE.md             Links to AGENTS.md (Claude does not natively support AGENTS.md)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # opsfile (aka `ops`)
 
+> **Website:** [seanseannery.github.io/opsfile](https://seanseannery.github.io/opsfile)
+
 ## What does `ops` do?
 
   It's a cli tool, essentially like `make` and `makefiles` but for sharing and executing live-operations / on-call commands for the repo.  Simply create an `Opsfile` in your repo with common on-call commands your team uses and run it with `ops [env] <command>`.

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="ops — like make, but for live operations commands">
+  <title>ops — live operations CLI</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <!-- HEADER -->
+  <header class="site-header">
+    <div class="container">
+      <span class="logo">ops</span>
+      <nav class="site-nav">
+        <a href="#install">Install</a>
+        <a href="#usage">Usage</a>
+        <a href="https://github.com/seanseannery/opsfile">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <!-- HERO -->
+  <section class="hero">
+    <div class="container">
+      <h1>ops</h1>
+      <p class="tagline">like make, but for live operations</p>
+      <p class="subtitle">Create an Opsfile. Run ops [env] [command]. Done.</p>
+      <div class="cta-buttons">
+        <a href="#install" class="btn-primary">Install</a>
+        <a href="https://github.com/seanseannery/opsfile" class="btn-secondary">View on GitHub</a>
+      </div>
+
+      <!-- TERMINAL DEMO -->
+      <div id="terminal-demo">
+        <div class="terminal-bar">
+          <span class="terminal-dot" style="background:#ff5f57;"></span>
+          <span class="terminal-dot" style="background:#febc2e;"></span>
+          <span class="terminal-dot" style="background:#28c840;"></span>
+        </div>
+        <div class="terminal-body">
+          <div class="line" style="animation-delay:0.5s;">
+            <span class="prompt">$</span><span class="cmd"> ops prod tail-logs</span>
+          </div>
+          <div class="line" style="animation-delay:1.5s;">
+            <span class="out">Fetching logs from /aws/ecs/my-service-prod ...</span>
+          </div>
+          <div class="line" style="animation-delay:2.5s;">
+            <span class="prompt">$</span><span class="cmd"> ops prod check-alarms</span>
+          </div>
+          <div class="line" style="animation-delay:3.5s;">
+            <span class="out">No alarms in ALARM state. All clear.</span>
+          </div>
+          <span class="cursor" style="animation-delay:3.5s;"></span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- INSTALL -->
+  <section id="install" class="install-section">
+    <div class="container">
+      <h2>Installation</h2>
+      <div class="install-tabs">
+        <button class="tab-btn" data-tab="tab-brew">Homebrew</button>
+        <button class="tab-btn" data-tab="tab-npm">npm</button>
+        <button class="tab-btn" data-tab="tab-curl">curl</button>
+      </div>
+
+      <div id="tab-brew" class="tab-content code-block">
+        <pre><code>brew tap seanseannery/opsfile https://github.com/seanseannery/opsfile
+brew install seanseannery/opsfile/opsfile</code></pre>
+      </div>
+
+      <div id="tab-npm" class="tab-content code-block">
+        <pre><code>npm install -g github:seanseannery/opsfile</code></pre>
+      </div>
+
+      <div id="tab-curl" class="tab-content code-block">
+        <pre><code>curl -fsSL https://raw.githubusercontent.com/seanseannery/opsfile/main/install/install.sh | bash</code></pre>
+      </div>
+    </div>
+  </section>
+
+  <!-- USAGE -->
+  <section id="usage" class="usage-section">
+    <div class="container">
+      <h2>Getting Started</h2>
+
+      <h3>Step 1: Create an Opsfile</h3>
+      <p>Create an <code>Opsfile</code> in your repo root. It uses Makefile-style syntax:</p>
+      <div class="opsfile-example code-block">
+        <pre><code># Variables — prefix with environment name to scope them
+prod_AWS_ACCOUNT=1234567
+preprod_AWS_ACCOUNT=8765431
+
+# Commands — define per-environment shell lines
+# Use "default" as a fallback when env-specific block is absent
+tail-logs:
+    default:
+        aws cloudwatch logs --tail $(AWS_ACCOUNT)
+    local:
+        docker logs myapp --follow
+
+list-instance-ips:
+    prod:
+        aws ec2 --list-instances
+    preprod:
+        aws ecs cluster --list-instances
+
+# Shell environment variables are injected automatically using the same $(VAR) syntax.
+# No declaration needed — if ops can't find it in the Opsfile, it falls back to env variables
+show-profile:
+    default:
+        echo "Using AWS profile: $(AWS_PROFILE)"</code></pre>
+      </div>
+
+      <h3>Step 2: Run ops commands</h3>
+      <p>Run commands with the following syntax:</p>
+      <div class="code-block">
+        <pre><code>ops [flags] &lt;your_environment&gt; &lt;your_command&gt; [any-command-args]</code></pre>
+      </div>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Flag</th>
+            <th>Short</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><td><code>--directory &lt;path&gt;</code></td><td><code>-D &lt;path&gt;</code></td><td>Use the Opsfile in the given directory</td></tr>
+          <tr><td><code>--dry-run</code></td><td><code>-d</code></td><td>Print resolved commands without executing</td></tr>
+          <tr><td><code>--silent</code></td><td><code>-s</code></td><td>Execute commands without printing output</td></tr>
+          <tr><td><code>--version</code></td><td><code>-v</code></td><td>Print the ops version and exit</td></tr>
+          <tr><td><code>--help</code></td><td><code>-h</code></td><td>Show usage information and exit</td></tr>
+        </tbody>
+      </table>
+
+      <h4>Examples:</h4>
+      <div class="code-block">
+        <pre><code>ops preprod instance-count
+ops prod open-dashboard
+ops local logs
+ops prod k8s -namespace myspace</code></pre>
+      </div>
+    </div>
+  </section>
+
+  <!-- FEATURES -->
+  <section class="features-section">
+    <div class="container">
+      <h2>Why use it?</h2>
+      <div class="feature-grid">
+        <div class="feature-card">
+          <div class="feature-icon">⚡</div>
+          <div class="feature-title">Less Stress</div>
+          <p>Quickly find the right command during a live outage</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon">🤖</div>
+          <div class="feature-title">Less AI tokens</div>
+          <p>Let agents run ops scripts instead of googling commands</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon">📖</div>
+          <div class="feature-title">Knowledge Sharing</div>
+          <p>Share runbooks with your team as code</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon">📦</div>
+          <div class="feature-title">Encapsulation</div>
+          <p>Keep your Makefile focused on CI/CD</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- LINKS -->
+  <section class="links-section">
+    <div class="container">
+      <h2>Links</h2>
+      <div class="links-grid">
+        <a href="https://github.com/seanseannery/opsfile" class="link-card">
+          <strong>GitHub Repo</strong>
+          <span>Source code and documentation</span>
+        </a>
+        <a href="https://github.com/seanseannery/opsfile/releases" class="link-card">
+          <strong>Releases</strong>
+          <span>Download binaries and changelogs</span>
+        </a>
+        <a href="https://github.com/seanseannery/opsfile/issues" class="link-card">
+          <strong>Issues</strong>
+          <span>Bug reports and feature requests</span>
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <!-- FOOTER -->
+  <footer class="site-footer">
+    <div class="container">
+      <p>© 2025 opsfile · MIT License · <a href="https://github.com/seanseannery/opsfile">GitHub</a></p>
+    </div>
+  </footer>
+
+  <script>
+    document.querySelectorAll('.tab-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+        document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+        btn.classList.add('active');
+        document.getElementById(btn.dataset.tab).classList.add('active');
+      });
+    });
+    document.querySelector('.tab-btn').click();
+  </script>
+
+</body>
+</html>

--- a/site/style.css
+++ b/site/style.css
@@ -1,0 +1,433 @@
+/* Solarized Dark — GitHub Pages stylesheet for ops CLI */
+
+/* ─── Color Palette ─────────────────────────────────────────── */
+:root {
+  --bg:       #002b36;  /* base03 - page background */
+  --bg-hl:    #073642;  /* base02 - card/code backgrounds */
+  --bg-hl2:   #0a4050;  /* slightly lighter, hover states */
+  --subtle:   #586e75;  /* base01 - borders, muted text */
+  --muted:    #657b83;  /* base00 */
+  --body:     #839496;  /* base0 - body text */
+  --emphasis: #93a1a1;  /* base1 - headings, emphasis */
+  --bright:   #fdf6e3;  /* base3 - high contrast text */
+  --yellow:   #b58900;
+  --orange:   #cb4b16;
+  --red:      #dc322f;
+  --cyan:     #2aa198;
+  --blue:     #268bd2;
+  --green:    #859900;
+}
+
+/* ─── Global ─────────────────────────────────────────────────── */
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  background: var(--bg);
+  color: var(--body);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+a {
+  color: var(--blue);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* ─── Header ─────────────────────────────────────────────────── */
+.site-header {
+  background: var(--bg-hl);
+  border-bottom: 1px solid var(--subtle);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  padding: 14px 0;
+}
+
+.site-header .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.logo {
+  font-weight: bold;
+  font-size: 1.4rem;
+  color: var(--cyan);
+  font-family: monospace;
+  letter-spacing: -1px;
+  text-decoration: none;
+}
+
+.logo:hover {
+  text-decoration: none;
+}
+
+.site-nav a {
+  color: var(--body);
+  margin-left: 20px;
+  font-size: 0.9rem;
+  text-decoration: none;
+}
+
+.site-nav a:hover {
+  color: var(--cyan);
+  text-decoration: none;
+}
+
+/* ─── Hero ───────────────────────────────────────────────────── */
+.hero {
+  padding: 80px 0 60px;
+  text-align: center;
+}
+
+.hero h1 {
+  font-size: 4rem;
+  color: var(--cyan);
+  font-family: monospace;
+  margin-bottom: 8px;
+  margin-top: 0;
+}
+
+.tagline {
+  font-size: 1.4rem;
+  color: var(--emphasis);
+  margin-bottom: 8px;
+}
+
+.subtitle {
+  color: var(--muted);
+  font-size: 1rem;
+  margin-bottom: 32px;
+}
+
+.cta-buttons {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.btn-primary,
+.btn-secondary {
+  display: inline-block;
+  padding: 10px 24px;
+  border-radius: 4px;
+  font-family: monospace;
+  text-decoration: none;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: background 0.2s, border-color 0.2s, color 0.2s;
+}
+
+.btn-primary {
+  background: var(--cyan);
+  color: var(--bg);
+  font-weight: bold;
+  border: none;
+}
+
+.btn-primary:hover {
+  background: var(--blue);
+  text-decoration: none;
+  color: var(--bg);
+}
+
+.btn-secondary {
+  border: 2px solid var(--subtle);
+  color: var(--emphasis);
+  background: none;
+}
+
+.btn-secondary:hover {
+  border-color: var(--cyan);
+  color: var(--cyan);
+  text-decoration: none;
+}
+
+/* ─── Terminal Demo ──────────────────────────────────────────── */
+#terminal-demo {
+  max-width: 640px;
+  margin: 40px auto;
+  background: var(--bg-hl);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+.terminal-bar {
+  background: var(--subtle);
+  padding: 10px 14px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.terminal-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.terminal-dot:nth-child(1) { background: var(--red); }
+.terminal-dot:nth-child(2) { background: var(--yellow); }
+.terminal-dot:nth-child(3) { background: var(--green); }
+
+.terminal-body {
+  padding: 20px;
+  font-family: monospace;
+  font-size: 0.9rem;
+  line-height: 1.8;
+}
+
+.line {
+  opacity: 0;
+  animation: appear 0.3s ease forwards;
+}
+
+.line:nth-child(1) { animation-delay: 0.5s; }
+.line:nth-child(2) { animation-delay: 1.5s; }
+.line:nth-child(3) { animation-delay: 2.5s; }
+.line:nth-child(4) { animation-delay: 3.5s; }
+
+.prompt { color: var(--green); }
+.cmd    { color: var(--bright); }
+.out    { color: var(--muted); }
+
+.cursor {
+  display: inline-block;
+  width: 8px;
+  height: 1.1em;
+  background: var(--cyan);
+  vertical-align: text-bottom;
+  animation: blink 1s step-end infinite;
+}
+
+@keyframes appear {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: none; }
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0; }
+}
+
+/* ─── Install Section ────────────────────────────────────────── */
+#install,
+.install-section {
+  padding: 64px 0;
+  background: var(--bg);
+}
+
+.install-section h2,
+#install h2 {
+  color: var(--emphasis);
+  margin-bottom: 32px;
+  font-family: monospace;
+}
+
+.install-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 0;
+  border-bottom: 2px solid var(--bg-hl);
+}
+
+.tab-btn {
+  background: none;
+  border: none;
+  color: var(--muted);
+  padding: 10px 20px;
+  cursor: pointer;
+  font-family: monospace;
+  font-size: 1rem;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.tab-btn:hover {
+  color: var(--emphasis);
+}
+
+.tab-btn.active {
+  color: var(--cyan);
+  border-bottom-color: var(--cyan);
+}
+
+.tab-content {
+  display: none;
+}
+
+.tab-content.active {
+  display: block;
+}
+
+.code-block {
+  background: var(--bg-hl);
+  border-radius: 0 4px 4px 4px;
+  padding: 20px;
+}
+
+pre > code {
+  font-family: monospace;
+  font-size: 0.9rem;
+  color: var(--bright);
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+/* ─── Usage Section ──────────────────────────────────────────── */
+#usage,
+.usage-section {
+  padding: 64px 0;
+  background: var(--bg-hl);
+}
+
+.usage-section h2,
+.usage-section h3,
+#usage h2,
+#usage h3 {
+  color: var(--emphasis);
+  font-family: monospace;
+}
+
+.opsfile-example {
+  background: var(--bg);
+  border-radius: 4px;
+  padding: 20px;
+  border-left: 3px solid var(--cyan);
+}
+
+.opsfile-example code {
+  color: var(--body);
+  font-size: 0.85rem;
+}
+
+/* ─── Features Section ───────────────────────────────────────── */
+.features-section {
+  padding: 64px 0;
+  background: var(--bg);
+  text-align: center;
+}
+
+.features-section h2 {
+  color: var(--emphasis);
+  font-family: monospace;
+  margin-bottom: 40px;
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 24px;
+}
+
+.feature-card {
+  background: var(--bg-hl);
+  border-radius: 6px;
+  padding: 24px;
+  border: 1px solid var(--subtle);
+  transition: border-color 0.2s, transform 0.2s;
+}
+
+.feature-card:hover {
+  border-color: var(--cyan);
+  transform: translateY(-2px);
+}
+
+.feature-icon {
+  font-size: 2rem;
+  margin-bottom: 12px;
+}
+
+.feature-title {
+  color: var(--cyan);
+  font-family: monospace;
+  font-weight: bold;
+  margin-bottom: 8px;
+}
+
+/* ─── Links Section ──────────────────────────────────────────── */
+.links-section {
+  padding: 48px 0;
+  background: var(--bg-hl);
+  text-align: center;
+}
+
+.links-section h2 {
+  color: var(--emphasis);
+  font-family: monospace;
+  margin-bottom: 32px;
+}
+
+.links-grid {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.link-card {
+  background: var(--bg);
+  border: 1px solid var(--subtle);
+  border-radius: 6px;
+  padding: 20px 32px;
+  color: var(--blue);
+  font-family: monospace;
+  text-decoration: none;
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.link-card:hover {
+  border-color: var(--cyan);
+  color: var(--cyan);
+  text-decoration: none;
+}
+
+/* ─── Footer ─────────────────────────────────────────────────── */
+.site-footer {
+  background: var(--bg);
+  border-top: 1px solid var(--subtle);
+  padding: 24px 0;
+  text-align: center;
+  color: var(--subtle);
+  font-size: 0.85rem;
+}
+
+.site-footer a {
+  color: var(--subtle);
+  text-decoration: none;
+}
+
+.site-footer a:hover {
+  color: var(--cyan);
+  text-decoration: none;
+}
+
+/* ─── Responsive ─────────────────────────────────────────────── */
+@media (max-width: 600px) {
+  .hero h1 { font-size: 2.5rem; }
+  .cta-buttons { flex-direction: column; align-items: center; }
+  #terminal-demo { margin: 24px 0; font-size: 0.8rem; }
+  .feature-grid { grid-template-columns: 1fr; }
+  .links-grid { flex-direction: column; align-items: center; }
+  .site-nav { display: none; }
+}


### PR DESCRIPTION
## Key Changes

- Add `site/index.html` — a fully structured GitHub Pages landing page for the `ops` CLI tool
- Includes header, hero with CSS-only animated terminal demo, install tabs (Homebrew/npm/curl), getting started usage section, feature cards, links section, and footer
- All copy sourced from README.md
- Tab switching via minimal inline JS as specified
- References `./style.css` for styling (to be provided by separate agent)

## Why do we need this?

Closes Issue#5. The `ops` project needs a public landing page hosted on GitHub Pages to improve discoverability and provide a polished first impression for users landing on the project URL. This HTML file provides the complete page structure and content, ready to be styled.

## New modules or other dependencies introduced

None. Plain HTML with no build dependencies.

## How was this tested?

- Manually reviewed HTML structure against the full spec
- All required class/id names verified present: `.site-header`, `.container`, `.logo`, `.site-nav`, `.hero`, `.tagline`, `.cta-buttons`, `.btn-primary`, `.btn-secondary`, `#terminal-demo`, `.terminal-bar`, `.terminal-dot`, `.terminal-body`, `.line`, `.prompt`, `.cmd`, `.out`, `.cursor`, `#install`, `.install-section`, `.install-tabs`, `.tab-btn`, `.tab-content`, `.code-block`, `#usage`, `.usage-section`, `.opsfile-example`, `.features-section`, `.feature-grid`, `.feature-card`, `.feature-icon`, `.feature-title`, `.links-section`, `.links-grid`, `.link-card`, `.site-footer`
- Tab switching JS verified against spec
- All install commands match README.md