### PR TITLE
feat: add GitHub Pages deploy workflow and update docs (Issue#5)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,33 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths: ['site/**']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@
     ├── .githooks/            Local git hooks: pre-push (lint+test), commit-msg (conventional commit format)
     │
     ├── Formula/              Homebrew tap formula — auto-updated by release.yml on each release
+    ├── site/                 GitHub Pages static landing page (HTML + CSS) — deployed by pages.yml
     ├── go.mod                Module declaration (sean_seannery/opsfile, Go 1.25+, no external deps)
     ├── AGENTS.md             This file — source of truth for agentic context
     ├── CLAUDE.md             Links to AGENTS.md (Claude does not natively support AGENTS.md)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # opsfile (aka `ops`)
 
+> **Website:** [seanseannery.github.io/opsfile](https://seanseannery.github.io/opsfile)
+
 ## What does `ops` do?
 
   It's a cli tool, essentially like `make` and `makefiles` but for sharing and executing live-operations / on-call commands for the repo.  Simply create an `Opsfile` in your repo with common on-call commands your team uses and run it with `ops [env] <command>`.


### PR DESCRIPTION
## Key Changes

- Add `.github/workflows/pages.yml`: GitHub Actions workflow that deploys the `site/` directory to GitHub Pages on push to `main` (path-filtered to `site/**`) and supports manual dispatch via `workflow_dispatch`.
- Update `README.md`: add website link (`seanseannery.github.io/opsfile`) below the H1 heading.
- Update `AGENTS.md`: add `site/` entry to the directory structure section.

## Why do we need this?

Closes Issue #5. The project has a static landing page in `site/` but no automated deployment pipeline. This workflow wires up GitHub Pages deployment so the site is automatically published whenever `site/` content is updated on `main`.

## New modules or other dependencies introduced

None. Uses only official GitHub Actions: `actions/checkout@v4`, `actions/configure-pages@v5`, `actions/upload-pages-artifact@v3`, `actions/deploy-pages@v4`.

## How was this tested?

- Workflow YAML validated against the GitHub Actions schema and the Pages deployment pattern from GitHub's official documentation.
- README and AGENTS.md changes reviewed visually to confirm correct placement and formatting.
- No Go code changed; `make lint` and `make test` not required for this change.