### PR TITLE
docs(site): GitHub Pages landing page polish

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/configure-pages@v5
+      - name: Copy install script into site
+        run: cp install/install.sh docs/site/install.sh
       - uses: actions/upload-pages-artifact@v3
         with:
           path: docs/site/

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   ### curl (MacOS / Linux)
 
   ```bash
-  curl -fsSL https://raw.githubusercontent.com/seanseannery/opsfile/main/install/install.sh | bash
+  curl -fsSL https://seanseannery.github.io/opsfile/install.sh | bash
   ```
   Detects your OS, downloads the correct binary from the [latest GitHub release](https://github.com/seanseannery/opsfile/releases/latest), and installs to `/usr/local/bin/ops`.
 

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -121,7 +121,7 @@ brew install seanseannery/opsfile/opsfile</code></pre>
         <span class="prompt">$</span> ops [flags] &lt;environment&gt; &lt;command&gt; [args]
       </div>
 
-      <table>
+      <table class="flags-table">
         <thead>
           <tr>
             <th>Flag</th>
@@ -172,6 +172,16 @@ brew install seanseannery/opsfile/opsfile</code></pre>
           <div class="feature-icon">📦</div>
           <div class="feature-title">Encapsulation</div>
           <p>Keep your Makefile focused on CI/CD</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon">🤝</div>
+          <div class="feature-title">Team Standardisation</div>
+          <p>No more tribal knowledge or Slack threads of bash one-liners. Opsfile lives in the repo — every teammate runs the same command, the same way, every time.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon">🔒</div>
+          <div class="feature-title">Secrets-Safe by Design</div>
+          <p>Reference secrets via environment variables — never commit credentials. Variables resolve from your shell at runtime, keeping sensitive values out of your repo.</p>
         </div>
       </div>
     </div>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -99,15 +99,15 @@ brew install seanseannery/opsfile/opsfile</code></pre>
 <span class="sh-comment"># Use "default" as a fallback when env-specific block is absent</span>
 <span class="sh-cmd">tail-logs</span>:
     <span class="sh-env">default</span>:
-        aws cloudwatch logs --tail <span class="sh-subst">$(AWS_ACCOUNT)</span>
+        aws logs tail /aws/ecs/my-service --follow --since 30m
     <span class="sh-env">local</span>:
-        docker logs myapp --follow
+        docker logs myapp --follow --tail 100
 
 <span class="sh-cmd">list-instance-ips</span>:
     <span class="sh-env">prod</span>:
-        aws ec2 --list-instances
+        aws ec2 describe-instances --filters "Name=tag:Env,Values=prod" --query "Reservations[*].Instances[*].PrivateIpAddress" --output text
     <span class="sh-env">preprod</span>:
-        aws ecs cluster --list-instances
+        aws ecs list-container-instances --cluster my-cluster-preprod --output text
 
 <span class="sh-comment"># Shell env vars are injected automatically — ops falls back to env if not in Opsfile</span>
 <span class="sh-cmd">show-profile</span>:

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -69,7 +69,7 @@
       </div>
 
       <div id="tab-curl" class="tab-content code-block">
-        <pre><code>curl -fsSL https://raw.githubusercontent.com/seanseannery/opsfile/main/install/install.sh | bash</code></pre>
+        <pre><code>curl -fsSL https://seanseannery.github.io/opsfile/install.sh | bash</code></pre>
       </div>
 
       <div id="tab-brew" class="tab-content code-block">

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -204,6 +204,10 @@ brew install seanseannery/opsfile/opsfile</code></pre>
           <strong>Issues</strong>
           <span>Bug reports and feature requests</span>
         </a>
+        <a href="https://github.com/seanseannery/opsfile/discussions" class="link-card">
+          <strong>Discussions</strong>
+          <span>Questions, ideas, and community</span>
+        </a>
       </div>
     </div>
   </section>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -215,7 +215,7 @@ brew install seanseannery/opsfile/opsfile</code></pre>
   <!-- FOOTER -->
   <footer class="site-footer">
     <div class="container">
-      <p>© 2025 opsfile · MIT License · <a href="https://github.com/seanseannery/opsfile">GitHub</a></p>
+      <p>© 2026 opsfile · MIT License · <a href="https://github.com/seanseannery/opsfile">GitHub</a></p>
     </div>
   </footer>
 

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -215,7 +215,7 @@ brew install seanseannery/opsfile/opsfile</code></pre>
   <!-- FOOTER -->
   <footer class="site-footer">
     <div class="container">
-      <p>© 2026 opsfile · MIT License · <a href="https://github.com/seanseannery/opsfile">GitHub</a></p>
+      <p>© 2026 seanseannery · MIT License · <a href="https://github.com/seanseannery/opsfile">GitHub</a></p>
     </div>
   </footer>
 

--- a/docs/site/style.css
+++ b/docs/site/style.css
@@ -373,6 +373,44 @@ pre > code {
   user-select: none;
 }
 
+/* ─── Flags Table ────────────────────────────────────────────── */
+.flags-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 20px 0;
+  font-size: 0.9rem;
+}
+
+.flags-table th {
+  background: var(--bg);
+  color: var(--cyan);
+  text-align: left;
+  padding: 10px 14px;
+  border-bottom: 2px solid var(--cyan);
+  font-family: monospace;
+  font-weight: bold;
+}
+
+.flags-table td {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--subtle);
+  vertical-align: top;
+  color: var(--body);
+}
+
+.flags-table tr:last-child td {
+  border-bottom: none;
+}
+
+.flags-table tr:hover td {
+  background: var(--bg);
+}
+
+.flags-table td code {
+  color: var(--orange);
+  font-family: monospace;
+}
+
 /* ─── Usage Section ──────────────────────────────────────────── */
 #usage,
 .usage-section {


### PR DESCRIPTION
## Summary

- Left-align terminal demo, 20s looping CSS animation, reorder install tabs (curl → Homebrew → npm)
- Rebrand to \"Opsfile\", fix tagline capitalisation, syntax-highlight Opsfile example, copy buttons on install blocks
- Style Step 2 as bash terminal blocks matching Step 1
- Moved `site/` → `docs/site/` and updated `pages.yml` path
- Add 2 feature cards: Team Standardisation, Secrets-Safe by Design
- Style flags table with cyan headers, left-aligned cells, orange code highlights
- Fix Opsfile example with accurate AWS CLI commands (`aws logs tail`, `aws ec2 describe-instances`)
- Add GitHub Discussions link to Links section
- Update copyright year to 2026, copyright holder to seanseannery
- Serve `install.sh` via GitHub Pages (`seanseannery.github.io/opsfile/install.sh`) for shorter curl URL; update README and site accordingly

## Test plan

- [ ] Review site visually at the Pages preview URL after merge
- [ ] Verify copy buttons copy correct text to clipboard
- [ ] Verify terminal animation loops every ~20s
- [ ] Verify `curl -fsSL https://seanseannery.github.io/opsfile/install.sh | bash` resolves after Pages redeploy
- [ ] Confirm all install tabs (curl, Homebrew, npm) display correctly