### PR TITLE
fix(ci): use PAT for release checkout to bypass branch protection on formula push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.OPSFILE_RELEASE_PAT }}
 
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
## Key Changes

- Use `OPSFILE_RELEASE_PAT` token in the release job's checkout step so the Homebrew formula push to main can bypass branch protection

## Why do we need this?

Branch protection on `main` requires changes go through a PR. The default `GITHUB_TOKEN` doesn't have permission to push directly. Using a PAT with Contents write access allows the release automation to push the formula update directly.

## New modules or other dependencies introduced

None — requires the `OPSFILE_RELEASE_PAT` repo secret (already configured).

## How was this tested?

Will be validated on the next release dispatch.