### PR TITLE
fix(flags): preserve parsed flags when --help is combined with -D

### DIFF
--- a/internal/flag_parser.go
+++ b/internal/flag_parser.go
@@ -64,20 +64,37 @@ Flags:`)
 		fs.PrintDefaults()
 	}
 
-	// -? is not a valid flag name; handle it before fs.Parse.
+	// -? is not a valid pflag name; strip it before fs.Parse so other flags
+	// (like -D) are still parsed and returned alongside ErrHelp.
+	helpQuestion := false
 	for _, a := range osArgs {
 		if a == "-?" {
-			fs.Usage()
-			return OpsFlags{}, nil, ErrHelp
+			helpQuestion = true
+			break
 		}
+	}
+	if helpQuestion {
+		filtered := make([]string, 0, len(osArgs))
+		for _, a := range osArgs {
+			if a != "-?" {
+				filtered = append(filtered, a)
+			}
+		}
+		osArgs = filtered
 	}
 
 	if err := fs.Parse(osArgs); err != nil {
 		if errors.Is(err, pflag.ErrHelp) {
-			return OpsFlags{}, nil, ErrHelp
+			return OpsFlags{Directory: *dir, DryRun: *dryRun, List: *list, Silent: *silent, Version: *ver}, nil, ErrHelp
 		}
 		return OpsFlags{}, nil, err
 	}
+
+	if helpQuestion {
+		fs.Usage()
+		return OpsFlags{Directory: *dir, DryRun: *dryRun, List: *list, Silent: *silent, Version: *ver}, nil, ErrHelp
+	}
+
 	return OpsFlags{Directory: *dir, DryRun: *dryRun, List: *list, Silent: *silent, Version: *ver}, fs.Args(), nil
 }
 

--- a/internal/flag_parser_test.go
+++ b/internal/flag_parser_test.go
@@ -126,6 +126,24 @@ func TestParseOpsFlags(t *testing.T) {
 			wantErr: ErrHelp,
 		},
 		{
+			name:      "-D combined with --help preserves Directory",
+			input:     []string{"-D", "/some/path", "--help"},
+			wantFlags: OpsFlags{Directory: "/some/path"},
+			wantErr:   ErrHelp,
+		},
+		{
+			name:      "-D combined with -? preserves Directory",
+			input:     []string{"-D", "/some/path", "-?"},
+			wantFlags: OpsFlags{Directory: "/some/path"},
+			wantErr:   ErrHelp,
+		},
+		{
+			name:      "-D combined with -h preserves Directory",
+			input:     []string{"-D", "/some/path", "-h"},
+			wantFlags: OpsFlags{Directory: "/some/path"},
+			wantErr:   ErrHelp,
+		},
+		{
 			name:      "-D with empty string value",
 			input:     []string{"-D", "", "prod", "cmd"},
 			wantFlags: OpsFlags{Directory: ""},
@@ -163,6 +181,7 @@ func TestParseOpsFlags(t *testing.T) {
 
 			if tc.wantErr != nil {
 				require.ErrorIs(t, err, tc.wantErr)
+				assert.Equal(t, tc.wantFlags, gotFlags)
 				return
 			}
 			if tc.wantErrSub != "" {


### PR DESCRIPTION
## Key Changes

- `ParseOpsFlags` now returns populated `OpsFlags` alongside `ErrHelp` instead of a zero-value struct, so flags like `-D` parsed before `--help`/`-h`/`-?` are preserved
- The `-?` handler now strips `-?` from args and still runs `fs.Parse` on the remaining flags before returning `ErrHelp`
- 3 new test cases verify `-D` is preserved when combined with each help variant (`--help`, `-h`, `-?`)
- Test harness updated to assert on `wantFlags` even in error cases

## Why do we need this?

When `-D /path --help` was passed, the `--help` path in `main.go` used `flags.Directory` to locate the Opsfile for the command listing. But `ParseOpsFlags` was returning `OpsFlags{}` (zero value) on all help paths, so `flags.Directory` was always empty and the Opsfile was never found. This broke the `--help` + `-D` integration added in #36.

Related to #19

## New modules or other dependencies introduced

None

## How was this tested?

- 3 new unit tests: `-D combined with --help`, `-D combined with -h`, `-D combined with -?` — all verify `OpsFlags.Directory` is populated alongside `ErrHelp`
- Manual smoke test: `ops -D ./examples --help` now shows the command listing
- `make lint` and `make test` pass