### PR TITLE
docs(site): add --list/-l flag to GitHub Pages flags table

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -132,6 +132,7 @@ brew install seanseannery/opsfile/opsfile</code></pre>
         <tbody>
           <tr><td><code>--directory &lt;path&gt;</code></td><td><code>-D &lt;path&gt;</code></td><td>Use the Opsfile in the given directory</td></tr>
           <tr><td><code>--dry-run</code></td><td><code>-d</code></td><td>Print resolved commands without executing</td></tr>
+          <tr><td><code>--list</code></td><td><code>-l</code></td><td>List available commands and environments</td></tr>
           <tr><td><code>--silent</code></td><td><code>-s</code></td><td>Execute commands without printing output</td></tr>
           <tr><td><code>--version</code></td><td><code>-v</code></td><td>Print the ops version and exit</td></tr>
           <tr><td><code>--help</code></td><td><code>-h</code></td><td>Show usage information and exit</td></tr>


### PR DESCRIPTION
## Key Changes

- Add `--list` / `-l` flag entry to the flags table in `docs/site/index.html`

## Why do we need this?

The `--list` flag was added in #36 but the GitHub Pages site flags table was not updated.

Related to #19

## New modules or other dependencies introduced

None

## How was this tested?

- Visual inspection of the HTML table row