### PR TITLE
feat: add @ prefix to suppress command echoing (Issue #6)

### DIFF
--- a/cmd/ops/main.go
+++ b/cmd/ops/main.go
@@ -83,7 +83,7 @@ func main() {
 	if flags.DryRun {
 		if !flags.Silent {
 			for _, line := range resolved.Lines {
-				fmt.Println(line)
+				fmt.Println(line.Text)
 			}
 		}
 		return
@@ -94,7 +94,7 @@ func main() {
 		shell = "/bin/sh"
 	}
 
-	if err := internal.Execute(resolved.Lines, shell); err != nil {
+	if err := internal.Execute(resolved.Lines, shell, flags.Silent, os.Stderr); err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
 			os.Exit(exitErr.ExitCode())

--- a/docs/feature-at-prefix-suppress.md
+++ b/docs/feature-at-prefix-suppress.md
@@ -1,0 +1,260 @@
+# Feature: @ Prefix to Suppress Command Echoing
+
+
+## 1. Problem Statement & High-Level Goals
+
+### Problem
+When `ops` executes commands from an Opsfile, users have no visibility into which shell lines are being run — the tool silently executes each line and only command output (stdout/stderr) is visible. This makes debugging difficult and differs from tools like `make`, which echo commands before execution. Conversely, for polished scripts with user-facing output, echoing setup commands creates noise. Users need both default visibility and granular suppression. (Issue #6)
+
+### Goals
+- [ ] Echo each command line to stderr before execution by default
+- [ ] Support `@` prefix on Opsfile command lines to suppress echoing for that line
+- [ ] Respect `--silent` flag as a global echo suppression override
+- [ ] Preserve existing `--dry-run` behavior (prints all resolved lines regardless of `@`)
+
+### Non-Goals
+- Suppressing command output (stdout/stderr) — `@` only suppresses the echoed command text, not the command's own output
+- Colorized or formatted echo output — plain text echo is sufficient for v1
+- Per-command (multi-line block) suppression via a single `@` — each line is independent unless joined by continuation
+
+---
+
+## 2. Functional Requirements
+
+### FR-1: Default Command Echoing
+By default, each resolved shell line is printed to stderr immediately before execution. This gives users visibility into what `ops` is running, similar to Make's default behavior. Echo output goes to stderr so it does not interfere with command stdout (important for piping).
+
+### FR-2: @ Prefix Suppression
+When an Opsfile command line begins with `@`, that line's echo is suppressed during execution. The `@` character is stripped before the line is passed to the shell — it is Opsfile syntax, not shell syntax. The command's own output (stdout/stderr) is unaffected.
+
+### FR-3: --silent Global Suppression
+When `--silent` (`-s`) is passed, all command echoing is suppressed regardless of whether lines have `@` prefixes. This provides a clean output mode for scripted/automated usage.
+
+### FR-4: --dry-run Compatibility
+`--dry-run` continues to print all resolved command lines to stdout (with `@` already stripped). The `@` prefix does not affect dry-run output. When both `--dry-run` and `--silent` are set, nothing is printed (existing behavior preserved).
+
+### FR-5: Multi-Line Command Handling
+For backslash-continuation lines (`\` at end of line), the parser joins fragments into a single line before the resolver sees them. If the first fragment starts with `@`, the joined line starts with `@` and the entire joined command is treated as silent. Each independent line in a multi-line command block is evaluated separately for `@`.
+
+An `@` appearing on a non-first continuation fragment (e.g., `aws logs \` / `@--follow`) is not treated as Opsfile syntax — it becomes part of the joined shell text (e.g., `aws logs @--follow`), since `@` detection only applies to the leading character of the final joined line.
+
+### FR-6: @ Detection on Trimmed Lines
+The parser applies `strings.TrimSpace()` to every raw Opsfile line before collecting it as a shell line. This means indentation is already stripped before the resolver sees the line, and `@` detection operates on the trimmed result. A line like `    @echo hello` in the Opsfile will have its indentation removed by the parser, producing `@echo hello`, which the resolver correctly detects as a silent line.
+
+### Example Usage
+
+Given an Opsfile:
+```
+REGION=us-east-1
+
+deploy:
+    # Deploy the application
+    prod:
+        @echo "Deploying to production..."
+        aws ecs update-service --cluster prod --service app --region $(REGION)
+```
+
+```bash
+# Default execution — echoes non-@ lines to stderr
+$ ops prod deploy
+Deploying to production...              # ← stdout from echo (no command echoed due to @)
+aws ecs update-service --cluster prod --service app --region us-east-1   # ← echoed to stderr
+{...ecs output...}                      # ← stdout from aws cli
+
+# With --silent — no echoing at all
+$ ops --silent prod deploy
+Deploying to production...              # ← stdout from echo command
+{...ecs output...}                      # ← stdout from aws cli
+
+# Dry-run — shows all resolved lines regardless of @
+$ ops --dry-run prod deploy
+echo "Deploying to production..."
+aws ecs update-service --cluster prod --service app --region us-east-1
+```
+
+---
+
+## 3. Non-Functional Requirements
+
+| ID | Category | Requirement | Notes |
+|----|----------|-------------|-------|
+| NFR-1 | Performance | Zero measurable overhead — one `fmt.Fprintln` per non-silent line | Negligible |
+| NFR-2 | Compatibility | Works on Linux, macOS; no platform-specific behavior | Echo uses standard stderr |
+| NFR-3 | Reliability | `@` stripping is deterministic; only leading `@` consumed | `@@cmd` → `@cmd` (one `@` stripped) |
+| NFR-4 | Backwards Compatibility | Existing Opsfiles without `@` gain echoing — this is a visible behavior change | Matches Make convention; `--silent` restores old quiet behavior. Release notes should document: "Commands are now echoed to stderr before execution (like Make). Use `--silent` or `@` prefix to suppress." |
+| NFR-5 | Maintainability | Test coverage for resolver `@` stripping and executor echo logic | Table-driven tests |
+
+---
+
+## 4. Architecture & Implementation Proposal
+
+### Overview
+The `@` prefix is stripped during command resolution (before variable substitution) and recorded as per-line metadata in a new `ResolvedLine` type. The executor uses this metadata plus a global silent flag to decide whether to echo each line before running it.
+
+### Component Design
+
+**New Type: `ResolvedLine`** (`internal/command_resolver.go`)
+```go
+type ResolvedLine struct {
+    Text   string
+    Silent bool // true when the Opsfile line had a leading @ prefix
+}
+```
+
+**Modified: `ResolvedCommand`** (`internal/command_resolver.go`)
+```go
+type ResolvedCommand struct {
+    Lines []ResolvedLine  // was []string
+}
+```
+
+**Modified: `Resolve()`** (`internal/command_resolver.go`)
+- Before calling `substituteVars()`, check for and strip leading `@`
+- Set `Silent: true` on the `ResolvedLine` if `@` was present
+
+**Modified: `Execute()`** (`internal/executor.go`)
+- New signature: `Execute(lines []ResolvedLine, shell string, silent bool, echo io.Writer) error`
+- The `echo` parameter is the destination for echoed command text (typically `os.Stderr`). This makes the function testable — tests can pass a `bytes.Buffer` to capture and assert on echo output.
+- Before each `cmd.Run()`: if `!silent && !line.Silent`, write `line.Text` to the `echo` writer
+
+### Data Flow
+```
+Opsfile line: "@echo hello $(VAR)"
+        |
+        v
+Parser: stores as-is in OpsCommand.Environments["prod"] = ["@echo hello $(VAR)"]
+        |
+        v
+Resolver: strips "@" → Silent=true, Text="echo hello $(VAR)"
+          substituteVars → Text="echo hello world"
+          → ResolvedLine{Text: "echo hello world", Silent: true}
+        |
+        v
+main.go: dry-run? → print line.Text
+         execute? → Execute(lines, shell, flags.Silent, os.Stderr)
+        |
+        v
+Executor: Silent=true → skip echo
+          exec.Command(shell, "-c", "echo hello world")
+```
+
+#### Sequence Diagram
+```
+main.go
+  │
+  ├─ Resolve(commandName, env, commands, vars)
+  │     │
+  │     └─ For each raw line:
+  │           ├─ Strip leading "@" → set Silent flag
+  │           ├─ substituteVars(strippedLine, env, vars)
+  │           └─ → ResolvedLine{Text, Silent}
+  │
+  ├─ If --dry-run:
+  │     └─ Print line.Text for each line (unless --silent)
+  │
+  └─ Execute(resolved.Lines, shell, flags.Silent, os.Stderr)
+        └─ For each line:
+              ├─ If !silent && !line.Silent → fmt.Fprintln(echo, line.Text)
+              ├─ exec.Command(shell, "-c", line.Text)
+              └─ cmd.Run() → stop on first error
+```
+
+### Key Design Decisions
+- **`ResolvedLine` struct over parallel `[]bool`:** Type-safe, self-documenting, extensible for future per-line metadata without changing signatures again
+- **Strip `@` in resolver, not parser or executor:** The `@` is Opsfile syntax (not shell syntax). Stripping before variable substitution means `@$(VAR)` works correctly. Keeping it out of the executor maintains separation of concerns.
+- **Echo to stderr, not stdout:** Follows Make convention. Prevents echoed commands from contaminating command output when piping (e.g., `ops prod get-id | xargs ...`)
+- **Single `@` consumed per line:** `@@echo` becomes `@echo` (a valid shell command). Matches Make behavior. No recursive stripping.
+- **`--silent` passed as executor parameter:** Keeps executor a pure function of its inputs, consistent with existing `shell` parameter pattern
+- **`io.Writer` for echo destination:** Rather than hardcoding `os.Stderr` in `Execute()`, the echo writer is injected as a parameter. This keeps the executor testable — unit tests pass a `bytes.Buffer` to capture and verify echo output without OS-level pipe redirection. Production callers pass `os.Stderr`.
+
+### Files to Create / Modify
+
+| File | Action | Description |
+|------|--------|-------------|
+| `internal/command_resolver.go` | Modify | Add `ResolvedLine` type, change `ResolvedCommand.Lines` to `[]ResolvedLine`, strip `@` in `Resolve()` |
+| `internal/executor.go` | Modify | Update `Execute()` signature to accept `[]ResolvedLine`, `silent bool`, and `io.Writer`; add conditional echo logic |
+| `cmd/ops/main.go` | Modify | Update dry-run loop to use `line.Text`, pass `flags.Silent` and `os.Stderr` to `Execute()` |
+| `internal/command_resolver_test.go` | Modify | Update assertions for `ResolvedLine` type, add `@` prefix test cases |
+| `internal/executor_test.go` | Modify | Update calls for new signature, add echo/silent test cases |
+| `docs/feature-command-execution.md` | Modify | Document default echoing, `@` prefix, `--silent` interaction |
+
+---
+
+## 5. Alternatives Considered
+
+### Alternative A: Strip @ in the Parser
+
+**Description:** Detect and strip `@` in `opsfile_parser.go` when collecting shell lines. Store metadata in `OpsCommand` (e.g., parallel `[]bool` or new struct).
+
+**Pros:**
+- Earliest possible stripping — downstream code never sees `@`
+
+**Cons:**
+- Requires changing `OpsCommand.Environments` type from `map[string][]string` to a more complex type
+- Larger blast radius — every consumer of `OpsCommand` must adapt
+- Mixes Opsfile syntax concerns into the line-collection state machine
+
+**Why not chosen:** The resolver is the natural transformation boundary. `OpsCommand` represents raw parsed data; `ResolvedCommand` represents execution-ready data. Metadata belongs in the resolved output.
+
+---
+
+### Alternative B: Strip @ in the Executor
+
+**Description:** Pass lines with `@` intact through the resolver. Have the executor check for and strip `@` before running.
+
+**Pros:**
+- Minimal type changes — `ResolvedCommand.Lines` stays `[]string`
+- Only one file changes significantly
+
+**Cons:**
+- Executor must understand Opsfile syntax — breaks separation of concerns
+- `@` would pass through variable substitution (harmless but semantically wrong)
+- `--dry-run` output would include `@` prefix (confusing — it's not shell syntax)
+
+**Why not chosen:** Violates the clean pipeline design where each stage transforms data for the next. The executor should receive execution-ready lines.
+
+---
+
+### Alternative C: No Default Echoing — @ Only Triggers Explicit Echoing
+
+**Description:** Keep the current silent-by-default behavior. Instead, `@` would mean "also echo this line" (inverse of Make).
+
+**Pros:**
+- No behavior change for existing Opsfiles
+
+**Cons:**
+- Opposite of Make convention — confusing for users familiar with Make
+- Contradicts Issue #6 requirements
+- Less useful — the common case is wanting to see what's running
+
+**Why not chosen:** Issue #6 explicitly requests Make-style behavior where `@` suppresses echoing, implying echoing should be the default.
+
+---
+
+## Open Questions
+- [ ] Should echoed lines have a visual prefix (e.g., `+ command` like `set -x`, or `$ command`)? Current proposal: no prefix, just the raw command text (matching Make).
+
+---
+
+## 6. Task Breakdown
+
+### Phase 1: Foundation
+- [ ] Add `ResolvedLine` struct to `internal/command_resolver.go`
+- [ ] Change `ResolvedCommand.Lines` from `[]string` to `[]ResolvedLine`
+- [ ] Update `Resolve()` to strip `@` prefix and populate `Silent` field
+- [ ] Update existing resolver tests for new type (add `lineTexts()` helper)
+- [ ] Add new resolver tests for `@` prefix stripping and edge cases
+
+### Phase 2: Integration
+- [ ] Update `Execute()` signature to accept `[]ResolvedLine`, `silent bool`, and `echo io.Writer`
+- [ ] Add conditional echo logic in `Execute()` using the injected writer
+- [ ] Update `cmd/ops/main.go` dry-run loop and `Execute()` call (pass `os.Stderr` as echo writer)
+- [ ] Update existing executor tests for new signature (add `toLines()` helper)
+- [ ] Add new executor tests for echo and silent behavior
+
+### Phase 3: Polish
+- [ ] Update `docs/feature-command-execution.md` with echoing behavior
+- [ ] Manual end-to-end testing with example Opsfiles
+- [ ] Run `make lint` and `make test` for final validation
+
+---

--- a/docs/testplans/testplan-at-prefix-suppress.md
+++ b/docs/testplans/testplan-at-prefix-suppress.md
@@ -1,0 +1,152 @@
+# Test Plan: @ Prefix to Suppress Command Echoing
+
+**Feature Doc:** [docs/feature-at-prefix-suppress.md](../feature-at-prefix-suppress.md)
+
+---
+
+## 1. Scope
+
+### In Scope
+- `@` prefix detection and stripping in the command resolver
+- `ResolvedLine` type with `Silent` metadata
+- Default command echoing to stderr in the executor
+- `--silent` flag global suppression of echoing
+- `--dry-run` compatibility (prints resolved lines with `@` already stripped)
+- Backslash continuation with `@` prefix
+- Indent continuation with `@` prefix
+- Variable substitution on lines with `@` prefix
+- Regression testing for existing resolver and executor behavior
+
+### Out of Scope
+- Suppression of command stdout/stderr output
+- Colorized or formatted echo output
+- Per-command block-level suppression
+
+---
+
+## 2. Test Objectives
+
+- Verify that `@` prefix is correctly stripped from resolved command lines and the `Silent` flag is set
+- Verify that the executor echoes non-silent lines to stderr and skips echoing for silent lines
+- Verify `--silent` flag suppresses all echoing regardless of `@` prefix
+- Verify `--dry-run` prints all resolved lines (with `@` stripped) and is unaffected by `@`
+- Verify no regressions in existing resolver, parser, or executor behavior after the `ResolvedLine` type change
+
+---
+
+## 3. Entry & Exit Criteria
+
+### Entry Criteria (prerequisites before testing begins)
+- [ ] Feature implementation is code-complete
+- [ ] Code compiles without errors (`make build`)
+- [ ] Existing tests still pass (`make test`)
+
+### Exit Criteria (conditions to consider testing complete)
+- [ ] All green path automated tests pass
+- [ ] All red path automated tests pass
+- [ ] All green/red manual tests have been run and pass
+- [ ] No regressions in related features
+- [ ] Test coverage does not decrease
+
+### Acceptance Criteria
+
+- [ ] Lines without `@` are echoed to stderr before execution
+- [ ] Lines with `@` prefix are NOT echoed, but still execute normally
+- [ ] `@` is stripped before the line is passed to the shell — it is not shell syntax
+- [ ] `--silent` suppresses all echoing regardless of `@` presence
+- [ ] `--dry-run` prints all resolved lines with `@` already stripped
+- [ ] `--dry-run --silent` prints nothing (existing behavior preserved)
+- [ ] `@@cmd` strips one `@` and executes `@cmd` (single-layer stripping)
+- [ ] Variable substitution works correctly on `@`-prefixed lines
+- [ ] Backslash continuation lines with `@` on the first fragment produce a single silent resolved line
+- [ ] No breaking changes to existing Opsfile parsing or command resolution
+
+---
+
+## 4. Green Path Tests
+
+| Short Title | Test Name | Input / Setup | Expected Outcome | Type |
+|---|---|---|---|---|
+| Basic @ strip | TestResolve_AtPrefixStripped | Opsfile line: `@echo hello` | `ResolvedLine{Text: "echo hello", Silent: true}` | automated (unit) |
+| No @ prefix | TestResolve_NoAtPrefix | Opsfile line: `echo hello` | `ResolvedLine{Text: "echo hello", Silent: false}` | automated (unit) |
+| Mixed @ and non-@ | TestResolve_MixedAtAndNonAt | Lines: `@echo setup`, `aws deploy` | First line Silent=true, second Silent=false | automated (unit) |
+| @ with variable sub | TestResolve_AtPrefixWithVariable | `@echo $(VAR)` with `VAR=hello` | `ResolvedLine{Text: "echo hello", Silent: true}` | automated (unit) |
+| @ with env-scoped var | TestResolve_AtPrefixWithScopedVariable | `@echo $(ACCT)` with `prod_ACCT=123` | `ResolvedLine{Text: "echo 123", Silent: true}` | automated (unit) |
+| @ with backslash cont. | TestResolve_AtPrefixWithBackslashContinuation | `@aws logs \` / `--follow` | Single `ResolvedLine{Text: "aws logs --follow", Silent: true}` | automated (unit) |
+| Executor echoes non-silent | TestExecute_EchoesNonSilentLine | `ResolvedLine{Text: "true", Silent: false}`, silent=false | Line text printed to stderr before execution | automated (unit) |
+| Executor skips silent line | TestExecute_SkipsSilentLine | `ResolvedLine{Text: "true", Silent: true}`, silent=false | No echo to stderr, command still executes | automated (unit) |
+| Executor global silent | TestExecute_GlobalSilentSuppressesAll | Non-silent lines, silent=true | No echo to stderr for any line | automated (unit) |
+| Dry-run with @ | DryRunAtPrefix | `@echo hello` with `--dry-run` | Prints `echo hello` to stdout (@ stripped) | manual verification |
+| Dry-run+silent with @ | DryRunSilentAtPrefix | `@echo hello` with `--dry-run --silent` | Prints nothing | manual verification |
+| Default echo to stderr | DefaultEchoStderr | `echo hello` (no @), default execution | Command echoed to stderr, output to stdout | manual verification |
+
+---
+
+## 5. Red Path Tests
+
+| Short Title | Test Name | Input / Setup | Expected Outcome | Type |
+|---|---|---|---|---|
+| @ on failing command | TestExecute_AtPrefixOnFailingCommand | `ResolvedLine{Text: "false", Silent: true}` | Command fails with exit code 1, no echo before failure | automated (unit) |
+| @ with missing variable | TestResolve_AtPrefixMissingVariable | `@echo $(MISSING)` | Error: variable not defined (same as without @) | automated (unit) |
+| @ with invalid shell | TestExecute_AtPrefixInvalidShell | Silent line, invalid shell path | Error from exec, no echo attempted | automated (unit) |
+
+---
+
+## 6. Edge Cases & Boundary Conditions
+
+| Short Title | Test Name | Input / Setup | Expected Outcome | Type |
+|---|---|---|---|---|
+| Double @@ prefix | TestResolve_DoubleAtPrefix | `@@echo hello` | `ResolvedLine{Text: "@echo hello", Silent: true}` — one @ stripped, one remains as shell text | automated (unit) |
+| @ only (no command) | TestResolve_AtPrefixOnly | Line is just `@` | `ResolvedLine{Text: "", Silent: true}` — empty command | automated (unit) |
+| @ with leading spaces | TestResolve_AtPrefixAfterSpaces | Raw line `  @echo hi` (spaces before @) | Depends on parser behavior: if TrimSpace is applied first, @ is detected; otherwise treated as shell text. Validate which. | automated (unit) |
+| @ with indent continuation | TestResolve_AtPrefixWithIndentContinuation | `@aws logs` / (indented) `--follow` | Single `ResolvedLine{Text: "aws logs --follow", Silent: true}` | automated (unit) |
+| @ on continuation line (not first) | TestResolve_AtOnContinuationFragment | `aws logs \` / `@--follow` | The `@` is on a continuation fragment, not the first line. Validate: should the `@` be treated as part of shell text? | automated (unit) |
+| Non-identifier $() with @ | TestResolve_AtPrefixNonIdentifierPassthrough | `@$(shell cmd)` | `ResolvedLine{Text: "$(shell cmd)", Silent: true}` — passthrough preserved | automated (unit) |
+| @ in middle of line | TestResolve_AtInMiddleOfLine | `echo user@host.com` | `ResolvedLine{Text: "echo user@host.com", Silent: false}` — only leading @ is special | automated (unit) |
+| @ in variable value | TestResolve_AtInVariableValue | `VAR=user@host`, line: `echo $(VAR)` | `ResolvedLine{Text: "echo user@host", Silent: false}` — @ in var value is not stripped | automated (unit) |
+| Empty lines list + silent | TestExecute_EmptyLinesWithSilent | Empty `[]ResolvedLine`, silent=true | No error, no output | automated (unit) |
+| Multi-line: some @ some not | TestResolve_MultiLineMixedAt | Lines: `@echo setup`, `echo deploy`, `@echo cleanup` | Three ResolvedLines with Silent: true, false, true respectively | automated (unit) |
+| @ with whitespace-only after | TestResolve_AtPrefixWhitespaceOnlyAfter | Line: `@   ` (@ followed by spaces) | `ResolvedLine{Text: "   ", Silent: true}` or `{Text: "", Silent: true}` depending on trimming | automated (unit) |
+| @ with backslash at EOF | TestResolve_AtPrefixBackslashTrailingEOF | `@aws logs \` at EOF (no next line) | Single `ResolvedLine{Text: "aws logs ", Silent: true}` — matches existing backslash-at-EOF behavior | automated (unit) |
+
+---
+
+## 9. Existing Automated Tests
+
+- `TestResolve_ExactEnvMatch` in `internal/command_resolver_test.go` (line 19) — references `got.Lines` as `[]string`; must be updated for `[]ResolvedLine`
+- `TestResolve_MultiLineCommand` in `internal/command_resolver_test.go` (line 295) — 2-line assertion on `got.Lines`; must be updated
+- All ~30 tests in `internal/command_resolver_test.go` that access `got.Lines[0]` or `got.Lines` — must migrate to use `.Text` field or a `lineTexts()` helper
+- `TestExecute` in `internal/executor_test.go` (line 12) — 7 subtests calling `Execute([]string{...}, shell)`; must update to `Execute([]ResolvedLine{...}, shell, silent)`
+- `TestExecute_ErrorWrapsCommandString` in `internal/executor_test.go` (line 72) — single call; must update signature
+- `TestExecute_InvalidShellPath` in `internal/executor_test.go` (line 78) — must update signature
+- `TestExecute_CommandWithPipe` in `internal/executor_test.go` (line 83) — must update signature
+- `TestExecute_StderrConnected` in `internal/executor_test.go` (line 88) — must update signature; note: this test validates stderr output from commands, which may now include echoed command text mixed in
+
+---
+
+## 10. Missing Automated Tests
+
+| Scenario | Type | What It Validates |
+|---|---|---|
+| `@` prefix stripped and `Silent` flag set in resolver | unit | Core `@` detection logic in `Resolve()` |
+| Mixed `@` and non-`@` lines produce correct `Silent` flags | unit | Per-line independence of `@` detection |
+| `@@` double prefix strips only one `@` | unit | NFR-3: single-layer stripping |
+| `@` with variable substitution | unit | `@` stripped before `substituteVars()` |
+| `@` with backslash continuation | unit | Parser joins fragments, `@` on first fragment marks whole line silent |
+| `@` mid-line (e.g., email address) is not stripped | unit | Only leading `@` is Opsfile syntax |
+| Executor echoes to stderr when `!silent && !line.Silent` | unit | Default echoing behavior (capture stderr in test) |
+| Executor skips echo when `line.Silent == true` | unit | Per-line suppression |
+| Executor skips all echo when `silent == true` | unit | Global `--silent` override |
+| `--dry-run` prints `line.Text` with `@` already stripped | e2e | Dry-run compatibility |
+| `--dry-run --silent` prints nothing | e2e | Combined flag behavior |
+| Existing executor tests pass with updated signature | unit | Regression — no behavior change for existing commands |
+| Existing resolver tests pass with `ResolvedLine` type | unit | Regression — no behavior change for existing resolution |
+
+---
+
+## Notes
+- **Breaking behavior change**: This feature introduces default command echoing to stderr. All existing Opsfile users will see this new output. The `--silent` flag restores the previous quiet behavior. This should be prominently documented in release notes.
+- **Test migration**: The `ResolvedCommand.Lines` type change from `[]string` to `[]ResolvedLine` requires updating every existing test that accesses `.Lines`. A `lineTexts(rc ResolvedCommand) []string` helper function in the test file would minimize churn and keep assertions readable.
+- **Stderr capture in executor tests**: Testing echo-to-stderr requires capturing stderr output in tests. Consider using an `io.Writer` parameter or a package-level `var echoWriter io.Writer = os.Stderr` that tests can override, rather than hardcoding `os.Stderr` in the `Execute()` function. The current design doc specifies `fmt.Fprintln(os.Stderr, ...)` which is not testable without OS-level pipe redirection.
+- **`TestExecute_StderrConnected` interaction**: This existing test validates that command stderr output works. After this change, the executor will also write echo output to stderr. The test should still pass (it only checks for no error), but be aware that stderr now has mixed content (echo + command stderr).
+- **Open question from design doc**: Whether echoed lines should have a visual prefix (e.g., `+ command` or `$ command`). Test plan assumes no prefix per the current proposal. If a prefix is added, echo-related tests would need to account for it.

--- a/internal/command_resolver.go
+++ b/internal/command_resolver.go
@@ -6,10 +6,18 @@ import (
 	"strings"
 )
 
+// ResolvedLine holds a single shell line after resolution, with per-line
+// metadata. Silent is true when the original Opsfile line had a leading @
+// prefix, indicating that the executor should not echo it before running.
+type ResolvedLine struct {
+	Text   string
+	Silent bool
+}
+
 // ResolvedCommand holds the shell lines for a command after environment
 // selection and variable substitution.
 type ResolvedCommand struct {
-	Lines []string
+	Lines []ResolvedLine
 }
 
 // Resolve selects the correct environment block for commandName and substitutes
@@ -35,13 +43,18 @@ func Resolve(commandName, env string, commands map[string]OpsCommand, vars OpsVa
 		return ResolvedCommand{}, err
 	}
 
-	lines := make([]string, 0, len(raw))
+	lines := make([]ResolvedLine, 0, len(raw))
 	for _, line := range raw {
+		silent := false
+		if strings.HasPrefix(line, "@") {
+			silent = true
+			line = line[1:]
+		}
 		substituted, err := substituteVars(line, env, vars)
 		if err != nil {
 			return ResolvedCommand{}, err
 		}
-		lines = append(lines, substituted)
+		lines = append(lines, ResolvedLine{Text: substituted, Silent: silent})
 	}
 	return ResolvedCommand{Lines: lines}, nil
 }

--- a/internal/command_resolver_test.go
+++ b/internal/command_resolver_test.go
@@ -16,6 +16,15 @@ func parseFixture(t *testing.T, content string) (OpsVariables, map[string]OpsCom
 	return vars, commands
 }
 
+// lineTexts extracts the Text field from each ResolvedLine for easy comparison.
+func lineTexts(rc ResolvedCommand) []string {
+	out := make([]string, len(rc.Lines))
+	for i, l := range rc.Lines {
+		out[i] = l.Text
+	}
+	return out
+}
+
 func TestResolve_ExactEnvMatch(t *testing.T) {
 	vars, commands := parseFixture(t, `
 list-instance-ips:
@@ -28,7 +37,7 @@ list-instance-ips:
 	got, err := Resolve("list-instance-ips", "prod", commands, vars)
 	require.NoError(t, err)
 	want := []string{`aws ec2 --list-instances`, `echo "done"`}
-	assert.Equal(t, want, got.Lines)
+	assert.Equal(t, want, lineTexts(got))
 }
 
 func TestResolve_EmptyCommandsMap(t *testing.T) {
@@ -60,7 +69,7 @@ my-cmd:
 `)
 	got, err := Resolve("my-cmd", "prod", commands, vars)
 	require.NoError(t, err)
-	assert.Equal(t, "echo hello world", got.Lines[0])
+	assert.Equal(t, "echo hello world", got.Lines[0].Text)
 }
 
 func TestResolve_VariableUsedMultipleTimes(t *testing.T) {
@@ -73,7 +82,7 @@ my-cmd:
 `)
 	got, err := Resolve("my-cmd", "prod", commands, vars)
 	require.NoError(t, err)
-	assert.Equal(t, "echo val and val", got.Lines[0])
+	assert.Equal(t, "echo val and val", got.Lines[0].Text)
 }
 
 func TestResolve_UnclosedDollarParen(t *testing.T) {
@@ -85,7 +94,7 @@ func TestResolve_UnclosedDollarParen(t *testing.T) {
 	vars := OpsVariables{}
 	got, err := Resolve("my-cmd", "prod", commands, vars)
 	require.NoError(t, err)
-	assert.Equal(t, "echo $(incomplete", got.Lines[0])
+	assert.Equal(t, "echo $(incomplete", got.Lines[0].Text)
 }
 
 func TestResolve_MixedIdentifierAndNonIdentifier(t *testing.T) {
@@ -98,7 +107,7 @@ my-cmd:
 `)
 	got, err := Resolve("my-cmd", "prod", commands, vars)
 	require.NoError(t, err)
-	assert.Equal(t, "hello $(shell cmd)", got.Lines[0])
+	assert.Equal(t, "hello $(shell cmd)", got.Lines[0].Text)
 }
 
 func TestResolve_DefaultFallbackVariableScoping(t *testing.T) {
@@ -112,7 +121,7 @@ my-cmd:
 `)
 	got, err := Resolve("my-cmd", "prod", commands, vars)
 	require.NoError(t, err)
-	assert.Equal(t, "echo prod-acct", got.Lines[0])
+	assert.Equal(t, "echo prod-acct", got.Lines[0].Text)
 }
 
 func TestResolve_SameVarReferencedTwice(t *testing.T) {
@@ -125,7 +134,7 @@ my-cmd:
 `)
 	got, err := Resolve("my-cmd", "prod", commands, vars)
 	require.NoError(t, err)
-	assert.Equal(t, "x x", got.Lines[0])
+	assert.Equal(t, "x x", got.Lines[0].Text)
 }
 
 func TestResolve_UnclosedDollarParenAtEnd(t *testing.T) {
@@ -137,7 +146,7 @@ func TestResolve_UnclosedDollarParenAtEnd(t *testing.T) {
 	vars := OpsVariables{}
 	got, err := Resolve("my-cmd", "prod", commands, vars)
 	require.NoError(t, err)
-	assert.Equal(t, "echo $(", got.Lines[0])
+	assert.Equal(t, "echo $(", got.Lines[0].Text)
 }
 
 func TestResolve_EmptyToken(t *testing.T) {
@@ -149,7 +158,7 @@ func TestResolve_EmptyToken(t *testing.T) {
 	vars := OpsVariables{}
 	got, err := Resolve("my-cmd", "prod", commands, vars)
 	require.NoError(t, err)
-	assert.Equal(t, "echo $()", got.Lines[0])
+	assert.Equal(t, "echo $()", got.Lines[0].Text)
 }
 
 func TestResolve_ScopedLookupPriority(t *testing.T) {
@@ -164,7 +173,7 @@ func TestResolve_ScopedLookupPriority(t *testing.T) {
 	}
 	got, err := Resolve("my-cmd", "prod", commands, vars)
 	require.NoError(t, err)
-	assert.Equal(t, "echo prod.example.com", got.Lines[0])
+	assert.Equal(t, "echo prod.example.com", got.Lines[0].Text)
 }
 
 func TestResolve_UnscopedFallbackDirect(t *testing.T) {
@@ -178,7 +187,7 @@ func TestResolve_UnscopedFallbackDirect(t *testing.T) {
 	}
 	got, err := Resolve("my-cmd", "prod", commands, vars)
 	require.NoError(t, err)
-	assert.Equal(t, "echo default.example.com", got.Lines[0])
+	assert.Equal(t, "echo default.example.com", got.Lines[0].Text)
 }
 
 func TestResolve_MissingVariableReturnsError(t *testing.T) {
@@ -204,7 +213,7 @@ tail-logs:
 	got, err := Resolve("tail-logs", "prod", commands, vars)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
-	assert.Equal(t, "aws cloudwatch logs --tail 1234567", got.Lines[0])
+	assert.Equal(t, "aws cloudwatch logs --tail 1234567", got.Lines[0].Text)
 }
 
 func TestResolve_LocalOverridesDefault(t *testing.T) {
@@ -218,7 +227,7 @@ tail-logs:
 	got, err := Resolve("tail-logs", "local", commands, vars)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
-	assert.Equal(t, "docker logs myapp --follow", got.Lines[0])
+	assert.Equal(t, "docker logs myapp --follow", got.Lines[0].Text)
 }
 
 func TestResolve_ScopedPriority(t *testing.T) {
@@ -232,7 +241,7 @@ tail-logs:
 `)
 	got, err := Resolve("tail-logs", "prod", commands, vars)
 	require.NoError(t, err)
-	assert.Equal(t, "echo scoped", got.Lines[0])
+	assert.Equal(t, "echo scoped", got.Lines[0].Text)
 }
 
 func TestResolve_UnscopedFallback(t *testing.T) {
@@ -245,7 +254,7 @@ tail-logs:
 `)
 	got, err := Resolve("tail-logs", "prod", commands, vars)
 	require.NoError(t, err)
-	assert.Equal(t, "echo unscoped", got.Lines[0])
+	assert.Equal(t, "echo unscoped", got.Lines[0].Text)
 }
 
 func TestResolve_CommandNotFound(t *testing.T) {
@@ -289,7 +298,7 @@ my-cmd:
 `)
 	got, err := Resolve("my-cmd", "prod", commands, vars)
 	require.NoError(t, err)
-	assert.Equal(t, "echo $(aws ec2 describe-instances)", got.Lines[0])
+	assert.Equal(t, "echo $(aws ec2 describe-instances)", got.Lines[0].Text)
 }
 
 func TestResolve_MultiLineCommand(t *testing.T) {
@@ -308,7 +317,7 @@ deploy:
 		"aws ecs describe-clusters --cluster my-cluster --region us-east-1",
 		`echo "done in us-east-1"`,
 	}
-	assert.Equal(t, want, got.Lines)
+	assert.Equal(t, want, lineTexts(got))
 }
 
 // --- Shell environment variable injection tests ---
@@ -322,7 +331,7 @@ func TestResolveVar_UnscopedShellEnvFallback(t *testing.T) {
 	}
 	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
 	require.NoError(t, err)
-	assert.Equal(t, "echo from-shell", got.Lines[0])
+	assert.Equal(t, "echo from-shell", got.Lines[0].Text)
 }
 
 func TestResolveVar_EnvScopedShellEnv(t *testing.T) {
@@ -334,7 +343,7 @@ func TestResolveVar_EnvScopedShellEnv(t *testing.T) {
 	}
 	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
 	require.NoError(t, err)
-	assert.Equal(t, "echo shell-scoped", got.Lines[0])
+	assert.Equal(t, "echo shell-scoped", got.Lines[0].Text)
 }
 
 func TestResolveVar_OpsfileEnvScopedBeatsShellEnvScoped(t *testing.T) {
@@ -347,7 +356,7 @@ func TestResolveVar_OpsfileEnvScopedBeatsShellEnvScoped(t *testing.T) {
 	vars := OpsVariables{"prod_VAR": "opsfile-scoped"}
 	got, err := Resolve("my-cmd", "prod", commands, vars)
 	require.NoError(t, err)
-	assert.Equal(t, "echo opsfile-scoped", got.Lines[0])
+	assert.Equal(t, "echo opsfile-scoped", got.Lines[0].Text)
 }
 
 func TestResolveVar_ShellEnvScopedBeatsOpsfileUnscoped(t *testing.T) {
@@ -360,7 +369,7 @@ func TestResolveVar_ShellEnvScopedBeatsOpsfileUnscoped(t *testing.T) {
 	vars := OpsVariables{"VAR": "opsfile-unscoped"}
 	got, err := Resolve("my-cmd", "prod", commands, vars)
 	require.NoError(t, err)
-	assert.Equal(t, "echo shell-scoped", got.Lines[0])
+	assert.Equal(t, "echo shell-scoped", got.Lines[0].Text)
 }
 
 func TestResolveVar_OpsfileUnscopedBeatsShellEnvUnscoped(t *testing.T) {
@@ -373,7 +382,7 @@ func TestResolveVar_OpsfileUnscopedBeatsShellEnvUnscoped(t *testing.T) {
 	vars := OpsVariables{"VAR": "opsfile-unscoped"}
 	got, err := Resolve("my-cmd", "prod", commands, vars)
 	require.NoError(t, err)
-	assert.Equal(t, "echo opsfile-unscoped", got.Lines[0])
+	assert.Equal(t, "echo opsfile-unscoped", got.Lines[0].Text)
 }
 
 func TestResolveVar_ShellEnvUnscopedIsLastResort(t *testing.T) {
@@ -385,7 +394,7 @@ func TestResolveVar_ShellEnvUnscopedIsLastResort(t *testing.T) {
 	}
 	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
 	require.NoError(t, err)
-	assert.Equal(t, "echo shell-unscoped", got.Lines[0])
+	assert.Equal(t, "echo shell-unscoped", got.Lines[0].Text)
 }
 
 func TestResolveVar_PriorityChain(t *testing.T) {
@@ -432,7 +441,7 @@ func TestResolveVar_PriorityChain(t *testing.T) {
 			}
 			got, err := Resolve("my-cmd", "prod", commands, tc.opsfileVars)
 			require.NoError(t, err)
-			assert.Equal(t, "echo "+tc.want, got.Lines[0])
+			assert.Equal(t, "echo "+tc.want, got.Lines[0].Text)
 		})
 	}
 }
@@ -447,7 +456,7 @@ func TestResolveVar_MixedSources(t *testing.T) {
 	}
 	got, err := Resolve("my-cmd", "prod", commands, vars)
 	require.NoError(t, err)
-	assert.Equal(t, "echo from-opsfile from-shell", got.Lines[0])
+	assert.Equal(t, "echo from-opsfile from-shell", got.Lines[0].Text)
 }
 
 func TestResolveVar_EmptyShellEnvValue(t *testing.T) {
@@ -459,7 +468,7 @@ func TestResolveVar_EmptyShellEnvValue(t *testing.T) {
 	}
 	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
 	require.NoError(t, err)
-	assert.Equal(t, "echo ", got.Lines[0])
+	assert.Equal(t, "echo ", got.Lines[0].Text)
 }
 
 func TestResolveVar_NonIdentifierUnaffectedByShellEnv(t *testing.T) {
@@ -471,7 +480,7 @@ func TestResolveVar_NonIdentifierUnaffectedByShellEnv(t *testing.T) {
 	}
 	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
 	require.NoError(t, err)
-	assert.Equal(t, "echo $(aws ec2 describe-instances)", got.Lines[0])
+	assert.Equal(t, "echo $(aws ec2 describe-instances)", got.Lines[0].Text)
 }
 
 func TestResolveVar_AbsentFromAllSources(t *testing.T) {
@@ -483,4 +492,265 @@ func TestResolveVar_AbsentFromAllSources(t *testing.T) {
 	_, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "not defined")
+}
+
+// --- @ prefix tests ---
+
+func TestResolve_AtPrefixStripped(t *testing.T) {
+	commands := map[string]OpsCommand{
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
+			"prod": {"@echo hello"},
+		}},
+	}
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "echo hello", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].Silent)
+}
+
+func TestResolve_NoAtPrefix(t *testing.T) {
+	commands := map[string]OpsCommand{
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
+			"prod": {"echo hello"},
+		}},
+	}
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "echo hello", got.Lines[0].Text)
+	assert.False(t, got.Lines[0].Silent)
+}
+
+func TestResolve_MixedAtAndNonAt(t *testing.T) {
+	commands := map[string]OpsCommand{
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
+			"prod": {"@echo setup", "aws deploy", "@echo cleanup"},
+		}},
+	}
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 3)
+	assert.Equal(t, "echo setup", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].Silent)
+	assert.Equal(t, "aws deploy", got.Lines[1].Text)
+	assert.False(t, got.Lines[1].Silent)
+	assert.Equal(t, "echo cleanup", got.Lines[2].Text)
+	assert.True(t, got.Lines[2].Silent)
+}
+
+func TestResolve_AtPrefixWithVariable(t *testing.T) {
+	vars, commands := parseFixture(t, `
+VAR=hello
+
+my-cmd:
+    default:
+        @echo $(VAR)
+`)
+	got, err := Resolve("my-cmd", "prod", commands, vars)
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "echo hello", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].Silent)
+}
+
+func TestResolve_AtPrefixWithScopedVariable(t *testing.T) {
+	vars, commands := parseFixture(t, `
+prod_ACCT=123
+
+my-cmd:
+    default:
+        @echo $(ACCT)
+`)
+	got, err := Resolve("my-cmd", "prod", commands, vars)
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "echo 123", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].Silent)
+}
+
+func TestResolve_AtPrefixWithBackslashContinuation(t *testing.T) {
+	vars, commands := parseFixture(t, `
+my-cmd:
+    prod:
+        @aws logs \
+            --follow
+`)
+	got, err := Resolve("my-cmd", "prod", commands, vars)
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "aws logs --follow", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].Silent)
+}
+
+func TestResolve_AtPrefixWithIndentContinuation(t *testing.T) {
+	vars, commands := parseFixture(t, `
+my-cmd:
+    prod:
+        @aws logs
+            --follow
+`)
+	got, err := Resolve("my-cmd", "prod", commands, vars)
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "aws logs --follow", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].Silent)
+}
+
+func TestResolve_DoubleAtPrefix(t *testing.T) {
+	commands := map[string]OpsCommand{
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
+			"prod": {"@@echo hello"},
+		}},
+	}
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "@echo hello", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].Silent)
+}
+
+func TestResolve_AtPrefixOnly(t *testing.T) {
+	commands := map[string]OpsCommand{
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
+			"prod": {"@"},
+		}},
+	}
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].Silent)
+}
+
+func TestResolve_AtInMiddleOfLine(t *testing.T) {
+	commands := map[string]OpsCommand{
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
+			"prod": {"echo user@host.com"},
+		}},
+	}
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "echo user@host.com", got.Lines[0].Text)
+	assert.False(t, got.Lines[0].Silent)
+}
+
+func TestResolve_AtInVariableValue(t *testing.T) {
+	vars, commands := parseFixture(t, `
+VAR=user@host
+
+my-cmd:
+    default:
+        echo $(VAR)
+`)
+	got, err := Resolve("my-cmd", "prod", commands, vars)
+	require.NoError(t, err)
+	assert.Equal(t, "echo user@host", got.Lines[0].Text)
+	assert.False(t, got.Lines[0].Silent)
+}
+
+func TestResolve_AtPrefixNonIdentifierPassthrough(t *testing.T) {
+	commands := map[string]OpsCommand{
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
+			"prod": {"@$(shell cmd)"},
+		}},
+	}
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "$(shell cmd)", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].Silent)
+}
+
+func TestResolve_AtPrefixMissingVariable(t *testing.T) {
+	commands := map[string]OpsCommand{
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
+			"prod": {"@echo $(MISSING)"},
+		}},
+	}
+	_, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "not defined")
+}
+
+func TestResolve_MultiLineMixedAt(t *testing.T) {
+	vars, commands := parseFixture(t, `
+my-cmd:
+    prod:
+        @echo setup
+        echo deploy
+        @echo cleanup
+`)
+	got, err := Resolve("my-cmd", "prod", commands, vars)
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 3)
+
+	wantTexts := []string{"echo setup", "echo deploy", "echo cleanup"}
+	wantSilent := []bool{true, false, true}
+	assert.Equal(t, wantTexts, lineTexts(got))
+	for i, line := range got.Lines {
+		assert.Equal(t, wantSilent[i], line.Silent, "line %d Silent", i)
+	}
+}
+
+func TestResolve_AtPrefixBackslashTrailingEOF(t *testing.T) {
+	content := `
+my-cmd:
+    prod:
+        @aws logs \`
+	_, commands, _, _, err := ParseOpsFile(writeTempOpsfile(t, content))
+	require.NoError(t, err)
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "aws logs ", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].Silent)
+}
+
+func TestResolve_AtOnContinuationFragment(t *testing.T) {
+	// @ on a non-first continuation fragment is part of the joined shell text,
+	// not Opsfile syntax (per FR-5).
+	vars, commands := parseFixture(t, `
+my-cmd:
+    prod:
+        aws logs \
+            @--follow
+`)
+	got, err := Resolve("my-cmd", "prod", commands, vars)
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "aws logs @--follow", got.Lines[0].Text)
+	assert.False(t, got.Lines[0].Silent)
+}
+
+func TestResolve_AtPrefixWhitespaceOnlyAfter(t *testing.T) {
+	// @ followed by only whitespace — silent flag set, text is the whitespace.
+	commands := map[string]OpsCommand{
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
+			"prod": {"@   "},
+		}},
+	}
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "   ", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].Silent)
+}
+
+func TestResolve_ExistingTestsNoSilent(t *testing.T) {
+	// Verify that existing commands without @ have Silent=false
+	vars, commands := parseFixture(t, `
+REGION=us-east-1
+
+deploy:
+    prod:
+        aws ecs update --region $(REGION)
+        echo done
+`)
+	got, err := Resolve("deploy", "prod", commands, vars)
+	require.NoError(t, err)
+	for i, line := range got.Lines {
+		assert.False(t, line.Silent, "line %d should not be silent", i)
+	}
 }

--- a/internal/executor.go
+++ b/internal/executor.go
@@ -2,22 +2,32 @@ package internal
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 )
 
-// Execute runs each shell line sequentially using the given shell binary.
-// Each command inherits the current process environment and has its
+// Execute runs each resolved shell line sequentially using the given shell
+// binary. Each command inherits the current process environment and has its
 // stdin/stdout/stderr connected to the terminal.
+//
+// When silent is false, each line's Text is printed to the echo writer before
+// execution — unless the line's Silent flag is set (from an @ prefix in the
+// Opsfile). When silent is true, no lines are echoed regardless of per-line
+// flags.
+//
 // Returns immediately on the first command failure.
-func Execute(lines []string, shell string) error {
+func Execute(lines []ResolvedLine, shell string, silent bool, echo io.Writer) error {
 	for _, line := range lines {
-		cmd := exec.Command(shell, "-c", line)
+		if !silent && !line.Silent {
+			fmt.Fprintln(echo, line.Text)
+		}
+		cmd := exec.Command(shell, "-c", line.Text)
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("running %q: %w", line, err)
+			return fmt.Errorf("running %q: %w", line.Text, err)
 		}
 	}
 	return nil

--- a/internal/executor_test.go
+++ b/internal/executor_test.go
@@ -1,7 +1,9 @@
 package internal
 
 import (
+	"bytes"
 	"errors"
+	"io"
 	"os/exec"
 	"testing"
 
@@ -9,54 +11,63 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// toLines converts plain strings into ResolvedLines with Silent=false.
+func toLines(texts ...string) []ResolvedLine {
+	lines := make([]ResolvedLine, 0, len(texts))
+	for _, t := range texts {
+		lines = append(lines, ResolvedLine{Text: t})
+	}
+	return lines
+}
+
 func TestExecute(t *testing.T) {
 	cases := []struct {
 		name         string
-		lines        []string
+		lines        []ResolvedLine
 		wantErr      bool
 		wantExitCode int
 	}{
 		{
 			name:  "single successful command",
-			lines: []string{"true"},
+			lines: toLines("true"),
 		},
 		{
 			name:  "multiple successful commands",
-			lines: []string{"true", "true", "true"},
+			lines: toLines("true", "true", "true"),
 		},
 		{
 			name:         "single failing command",
-			lines:        []string{"false"},
+			lines:        toLines("false"),
 			wantErr:      true,
 			wantExitCode: 1,
 		},
 		{
 			name:         "stops on first failure",
-			lines:        []string{"false", "true"},
+			lines:        toLines("false", "true"),
 			wantErr:      true,
 			wantExitCode: 1,
 		},
 		{
 			name:         "middle command fails",
-			lines:        []string{"true", "false", "true"},
+			lines:        toLines("true", "false", "true"),
 			wantErr:      true,
 			wantExitCode: 1,
 		},
 		{
 			name:         "exit code is propagated",
-			lines:        []string{"exit 42"},
+			lines:        toLines("exit 42"),
 			wantErr:      true,
 			wantExitCode: 42,
 		},
 		{
 			name:  "empty lines list",
-			lines: []string{},
+			lines: []ResolvedLine{},
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := Execute(tc.lines, "/bin/sh")
+			err := Execute(tc.lines, "/bin/sh", false, io.Discard)
 			if tc.wantErr {
 				require.Error(t, err)
 				var exitErr *exec.ExitError
@@ -70,23 +81,102 @@ func TestExecute(t *testing.T) {
 }
 
 func TestExecute_ErrorWrapsCommandString(t *testing.T) {
-	err := Execute([]string{"this-command-does-not-exist-at-all"}, "/bin/sh")
+	err := Execute(toLines("this-command-does-not-exist-at-all"), "/bin/sh", false, io.Discard)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "this-command-does-not-exist-at-all")
 }
 
 func TestExecute_InvalidShellPath(t *testing.T) {
-	err := Execute([]string{"echo hello"}, "/nonexistent/shell/binary")
+	err := Execute(toLines("echo hello"), "/nonexistent/shell/binary", false, io.Discard)
 	require.Error(t, err)
 }
 
 func TestExecute_CommandWithPipe(t *testing.T) {
-	err := Execute([]string{"echo hello | cat"}, "/bin/sh")
+	err := Execute(toLines("echo hello | cat"), "/bin/sh", false, io.Discard)
 	assert.NoError(t, err)
 }
 
 func TestExecute_StderrConnected(t *testing.T) {
 	// A command writing to stderr should not cause an error by itself.
-	err := Execute([]string{"echo error-output >&2"}, "/bin/sh")
+	err := Execute(toLines("echo error-output >&2"), "/bin/sh", false, io.Discard)
 	assert.NoError(t, err)
+}
+
+// --- Echo behavior tests ---
+
+func TestExecute_EchoesNonSilentLine(t *testing.T) {
+	var buf bytes.Buffer
+	err := Execute([]ResolvedLine{
+		{Text: "true", Silent: false},
+	}, "/bin/sh", false, &buf)
+	require.NoError(t, err)
+	assert.Equal(t, "true\n", buf.String())
+}
+
+func TestExecute_SkipsSilentLine(t *testing.T) {
+	var buf bytes.Buffer
+	err := Execute([]ResolvedLine{
+		{Text: "true", Silent: true},
+	}, "/bin/sh", false, &buf)
+	require.NoError(t, err)
+	assert.Empty(t, buf.String())
+}
+
+func TestExecute_GlobalSilentSuppressesAll(t *testing.T) {
+	var buf bytes.Buffer
+	err := Execute([]ResolvedLine{
+		{Text: "true", Silent: false},
+		{Text: "true", Silent: true},
+	}, "/bin/sh", true, &buf)
+	require.NoError(t, err)
+	assert.Empty(t, buf.String())
+}
+
+func TestExecute_MixedSilentAndNonSilent(t *testing.T) {
+	var buf bytes.Buffer
+	err := Execute([]ResolvedLine{
+		{Text: "true", Silent: true},
+		{Text: "echo hello", Silent: false},
+		{Text: "true", Silent: true},
+	}, "/bin/sh", false, &buf)
+	require.NoError(t, err)
+	assert.Equal(t, "echo hello\n", buf.String())
+}
+
+func TestExecute_EchoMultipleNonSilentLines(t *testing.T) {
+	var buf bytes.Buffer
+	err := Execute([]ResolvedLine{
+		{Text: "true", Silent: false},
+		{Text: "echo hi", Silent: false},
+	}, "/bin/sh", false, &buf)
+	require.NoError(t, err)
+	assert.Equal(t, "true\necho hi\n", buf.String())
+}
+
+func TestExecute_AtPrefixOnFailingCommand(t *testing.T) {
+	var buf bytes.Buffer
+	err := Execute([]ResolvedLine{
+		{Text: "false", Silent: true},
+	}, "/bin/sh", false, &buf)
+	require.Error(t, err)
+	var exitErr *exec.ExitError
+	require.True(t, errors.As(err, &exitErr))
+	assert.Equal(t, 1, exitErr.ExitCode())
+	assert.Empty(t, buf.String())
+}
+
+func TestExecute_AtPrefixInvalidShell(t *testing.T) {
+	var buf bytes.Buffer
+	err := Execute([]ResolvedLine{
+		{Text: "echo hello", Silent: true},
+	}, "/nonexistent/shell/binary", false, &buf)
+	require.Error(t, err)
+	assert.Empty(t, buf.String())
+}
+
+func TestExecute_EmptyLinesWithSilent(t *testing.T) {
+	var buf bytes.Buffer
+	err := Execute([]ResolvedLine{}, "/bin/sh", true, &buf)
+	require.NoError(t, err)
+	assert.Empty(t, buf.String())
 }


### PR DESCRIPTION
## Key Changes

- Commands are now echoed to stderr before execution by default (like Make)
- Added `@` prefix support: prefixing an Opsfile command line with `@` suppresses echoing for that line
- `--silent` flag suppresses all echoing globally
- `--dry-run` prints all resolved lines with `@` stripped (unaffected by prefix)
- New `ResolvedLine` struct carries per-line `Silent` metadata through the pipeline
- `Execute()` now accepts an `io.Writer` for echo output (testable, passes `os.Stderr` in production)

## Why do we need this?

Users have no visibility into which shell lines are being run. This matches Make's behavior where commands are echoed before execution, and `@` prefix provides granular suppression for cleaner output. Closes #6.

## New modules or other dependencies introduced

None

## How was this tested?

- 18 new resolver tests covering `@` stripping, variable substitution with `@`, backslash/indent continuation, double `@@`, bare `@`, `@` in middle of line, `@` in variable values, and regression checks
- 8 new executor tests covering echo output, silent line suppression, global silent flag, mixed scenarios, and error cases
- All 97 tests pass, `make lint` clean
- Design doc: `docs/feature-at-prefix-suppress.md`
- Test plan: `docs/testplans/testplan-at-prefix-suppress.md`