### PR TITLE
ci: fix release note noise and ordering

### DIFF
--- a/.github/workflows/cliff.toml
+++ b/.github/workflows/cliff.toml
@@ -11,16 +11,12 @@ trim = true
 
 [git]
 conventional_commits  = true
-filter_unconventional = false
+filter_unconventional = true
 tag_pattern           = "v[0-9].*"
 
 commit_parsers = [
-  { message = "^feat",     group = "Features"       },
-  { message = "^fix",      group = "Bug Fixes"       },
-  { message = "^docs",     group = "Documentation"   },
-  { message = "^refactor", group = "Refactoring"     },
-  { message = "^test",     group = "Tests"           },
-  { message = "^ci",       group = "CI/CD"           },
-  { message = "^chore",    group = "Chores"          },
-  { message = ".*",        group = "Other"           },
+  { message = "^feat",     group = "Features (feat:*)"       },
+  { message = "^fix",      group = "Bug Fixes (fix:*)"       },
+  { message = "^docs",     group = "Documentation (docs:*)"   },
+  { message = ".*",        group = "Other (*)"           },
 ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,6 @@ jobs:
       - name: Upload GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
           tag_name: ${{ steps.version.outputs.version }}
           name: ${{ steps.version.outputs.version }}
           body: ${{ steps.changelog.outputs.content }}


### PR DESCRIPTION
## Key Changes

Changed filtering logic of releasenotes in cliff.toml

## Why do we need this?

Release notes higlighted a bunch of noise changes that users dont generally care about.

## New modules or other dependencies introduced

N/A

## How was this tested?

N/A