### PR TITLE
feat: add - prefix to ignore non-zero exit codes in Opsfile commands (Issue #20)

### DIFF
--- a/docs/feat-dash-prefix-silent-failure.md
+++ b/docs/feat-dash-prefix-silent-failure.md
@@ -1,0 +1,326 @@
+# Feature: `-` Prefix to Ignore Non-Zero Exit Codes (Issue #20)
+
+
+## 1. Problem Statement & High-Level Goals
+
+### Problem
+Currently, `ops` stops execution on the first shell line that returns a non-zero exit code (fail-fast behavior). This is appropriate for most workflows, but some operations include lines that may legitimately fail without indicating a real problem (e.g., `rm -f`, `docker stop` on a container that may not be running, `killall` on a process that may not exist). Users have no way to express "ignore failure on this line and continue" within an Opsfile. In Makefiles, the `-` prefix serves this purpose. (Issue #20)
+
+### Goals
+- [ ] Support `-` prefix on Opsfile shell lines to ignore non-zero exit codes and continue execution
+- [ ] For multi-line commands (backslash continuation and indent continuation), `-` on the first line applies to the entire joined command
+- [ ] Support combined `-@` and `@-` prefixes in either order (order-independent)
+- [ ] Update example Opsfile with `-` prefix usage
+- [ ] Add unit and integration tests
+
+### Non-Goals
+- Suppressing stderr output from the failing command -- `-` only ignores the exit code, it does not hide output
+- Applying `-` to an entire command block (all lines) via a single annotation -- each line is independent
+- Retry logic or conditional execution based on exit codes -- `-` is binary: ignore or fail
+
+---
+
+## 2. Functional Requirements
+
+### FR-1: Dash Prefix Ignores Non-Zero Exit Codes
+When an Opsfile command line begins with `-`, any non-zero exit code from that line is ignored and execution proceeds to the next line. The `-` character is stripped before the line is passed to the shell -- it is Opsfile syntax, not shell syntax. The command's stdout and stderr output are unaffected.
+
+### FR-2: Multi-Line Command Inheritance
+For backslash-continuation lines (`\` at end of line) and indent-continuation lines, the parser joins fragments into a single line before the resolver sees them. If the first fragment starts with `-`, the entire joined command inherits the ignore-failure behavior. The `-` does not need to appear on subsequent continuation fragments. A `-` appearing on a non-first continuation fragment is part of the joined shell text, not Opsfile syntax (same behavior as `@`).
+
+### FR-3: Combined Prefix Support (`-@` and `@-`)
+Both `-@` and `@-` are valid and equivalent. When both prefixes are present, the line has its echo suppressed (`@` behavior) AND its non-zero exit code ignored (`-` behavior). The resolver strips both prefix characters regardless of order before passing the remainder to variable substitution.
+
+### FR-4: Dry-Run Interaction
+When `--dry-run` is set, all resolved command lines are printed to stdout (with `-` and `@` already stripped). The `-` prefix does not affect dry-run output. Dry-run should show the command as it would be executed, without prefix syntax.
+
+### FR-5: Single Prefix Consumed Per Character
+`--echo hello` becomes `-echo hello` (one `-` stripped, `IgnoreError: true`). This mirrors how `@@echo` becomes `@echo` (one `@` stripped). Only one leading `-` and one leading `@` are consumed as Opsfile syntax; anything remaining is shell text.
+
+### FR-6: Dash in Middle of Line
+A `-` character appearing anywhere other than the leading position of a resolved line is not treated as Opsfile syntax. For example, `kubectl delete --force` or `echo "hello-world"` are unaffected. This is consistent with how `@` is only significant at the leading position.
+
+### Example Usage
+
+Given an Opsfile:
+```
+cleanup:
+    default:
+        -docker stop my-app
+        -docker rm my-app
+        docker run -d --name my-app my-image
+        @echo "Deployment complete"
+
+teardown:
+    prod:
+        -@kubectl delete pod old-pod
+        -killall background-worker
+        echo "Teardown finished"
+```
+
+```bash
+# Normal execution -- docker stop/rm may fail if container doesn't exist, but execution continues
+$ ops default cleanup
+docker stop my-app                    # echoed to stderr
+Error response from daemon: ...       # stderr from docker (container not running -- ignored)
+docker rm my-app                      # echoed to stderr
+Error: No such container: my-app      # stderr from docker -- ignored
+docker run -d --name my-app my-image  # echoed to stderr
+abc123def456                          # stdout from docker run
+Deployment complete                   # stdout from echo (not echoed due to @)
+
+# Dry-run -- shows resolved commands without prefixes
+$ ops --dry-run default cleanup
+docker stop my-app
+docker rm my-app
+docker run -d --name my-app my-image
+echo "Deployment complete"
+
+# Combined prefix -- both @ and - applied
+$ ops prod teardown
+                                      # kubectl line: not echoed (@), exit code ignored (-)
+killall background-worker             # echoed to stderr, exit code ignored (-)
+echo "Teardown finished"              # echoed to stderr
+Teardown finished                     # stdout from echo
+```
+
+---
+
+## 3. Non-Functional Requirements
+
+| ID | Category | Requirement | Notes |
+|----|----------|-------------|-------|
+| NFR-1 | Performance | Zero measurable overhead -- one conditional check per line | Negligible |
+| NFR-2 | Compatibility | Works on Linux and macOS; no platform-specific behavior | Uses existing exec.Command path |
+| NFR-3 | Reliability | Prefix stripping is deterministic; only one leading `-` consumed | `--cmd` becomes `-cmd` |
+| NFR-4 | Backwards Compatibility | No behavior change for existing Opsfiles -- `-` prefix is opt-in | Existing fail-fast behavior unchanged |
+| NFR-5 | Maintainability | Test coverage for resolver `-` stripping, combined prefixes, and executor ignore-error logic | Table-driven tests |
+
+---
+
+## 4. Architecture & Implementation Proposal
+
+### Overview
+The `-` prefix follows the same architectural pattern established by the `@` prefix (Issue #6). It is detected and stripped during command resolution in `Resolve()`, recorded as per-line metadata in the existing `ResolvedLine` struct, and acted upon during execution in `Execute()`. This keeps the parser, resolver, and executor responsibilities clean and consistent.
+
+### Component Design
+
+**Modified: `ResolvedLine`** (`internal/command_resolver.go`)
+```go
+type ResolvedLine struct {
+    Text        string
+    Silent      bool // true when the Opsfile line had a leading @ prefix
+    IgnoreError bool // true when the Opsfile line had a leading - prefix
+}
+```
+
+**Modified: `Resolve()`** (`internal/command_resolver.go`)
+
+The current prefix-stripping logic handles only `@`:
+```go
+if strings.HasPrefix(line, "@") {
+    silent = true
+    line = line[1:]
+}
+```
+
+This must be replaced with a loop that handles both `@` and `-` in any order, consuming at most one of each:
+```go
+silent := false
+ignoreError := false
+for len(line) > 0 {
+    switch line[0] {
+    case '@':
+        if !silent {
+            silent = true
+            line = line[1:]
+            continue
+        }
+    case '-':
+        if !ignoreError {
+            ignoreError = true
+            line = line[1:]
+            continue
+        }
+    }
+    break
+}
+```
+
+This approach:
+- Handles `@-`, `-@`, `@`, `-`, and bare lines uniformly
+- Consumes at most one `@` and one `-` (so `@@` strips one `@`, `--` strips one `-`)
+- Preserves the remaining line text for variable substitution
+- Runs in O(1) since at most two iterations occur
+
+**Modified: `Execute()`** (`internal/executor.go`)
+
+The current error handling returns immediately on failure:
+```go
+if err := cmd.Run(); err != nil {
+    return fmt.Errorf("running %q: %w", line.Text, err)
+}
+```
+
+When `line.IgnoreError` is true, the error is discarded and execution continues:
+```go
+if err := cmd.Run(); err != nil {
+    if !line.IgnoreError {
+        return fmt.Errorf("running %q: %w", line.Text, err)
+    }
+}
+```
+
+No changes to echo logic -- `Silent` and `IgnoreError` are orthogonal concerns.
+
+### Data Flow
+```
+Opsfile line: "-@docker stop old-app"
+        |
+        v
+Parser: stores as-is in OpsCommand.Environments["default"] = ["-@docker stop old-app"]
+        |
+        v
+Resolver: strips "-" -> IgnoreError=true
+          strips "@" -> Silent=true
+          remaining text: "docker stop old-app"
+          substituteVars -> Text="docker stop old-app"
+          -> ResolvedLine{Text: "docker stop old-app", Silent: true, IgnoreError: true}
+        |
+        v
+main.go: dry-run? -> print line.Text (no prefixes shown)
+         execute? -> Execute(lines, shell, flags.Silent, os.Stderr)
+        |
+        v
+Executor: Silent=true -> skip echo
+          exec.Command(shell, "-c", "docker stop old-app")
+          cmd.Run() returns exit code 1
+          IgnoreError=true -> discard error, continue to next line
+```
+
+#### Sequence Diagram
+```
+main.go
+  |
+  +-- Resolve(commandName, env, commands, vars)
+  |     |
+  |     +-- For each raw line:
+  |           +-- Strip leading "@" -> set Silent flag (at most once)
+  |           +-- Strip leading "-" -> set IgnoreError flag (at most once)
+  |           +-- substituteVars(strippedLine, env, vars)
+  |           +-- -> ResolvedLine{Text, Silent, IgnoreError}
+  |
+  +-- If --dry-run:
+  |     +-- Print line.Text for each line (unless --silent)
+  |
+  +-- Execute(resolved.Lines, shell, flags.Silent, os.Stderr)
+        +-- For each line:
+              +-- If !silent && !line.Silent -> fmt.Fprintln(echo, line.Text)
+              +-- exec.Command(shell, "-c", line.Text)
+              +-- cmd.Run()
+              +-- If err != nil && !line.IgnoreError -> return error
+              +-- If err != nil && line.IgnoreError -> continue
+```
+
+### Key Design Decisions
+
+- **Add `IgnoreError` field to existing `ResolvedLine` rather than a new type:** The `ResolvedLine` struct was designed to hold per-line metadata (Issue #6 added `Silent`). Adding `IgnoreError` is the natural extension. No new types needed.
+- **Strip `-` in resolver, not parser or executor:** Consistent with the `@` prefix architecture. The resolver is the transformation boundary between raw Opsfile syntax and execution-ready commands. The parser stores raw text; the executor receives clean commands with metadata.
+- **Loop-based prefix stripping over sequential if-checks:** A loop naturally handles any ordering of `@` and `-` without duplicating logic for each permutation. The `if !silent` / `if !ignoreError` guards ensure at most one of each is consumed.
+- **`IgnoreError` is orthogonal to `Silent`:** They are independent concerns. A line can be silent, ignore errors, both, or neither. No interaction between them in the executor beyond both being fields on the same struct.
+- **Dry-run shows the command without prefixes:** Consistent with `@` behavior. The user sees the actual shell command that would execute, not Opsfile syntax.
+
+### Files to Create / Modify
+
+| File | Action | Description |
+|------|--------|-------------|
+| `internal/command_resolver.go` | Modify | Add `IgnoreError` field to `ResolvedLine`; refactor prefix stripping in `Resolve()` to handle both `@` and `-` in any order |
+| `internal/executor.go` | Modify | Add `IgnoreError` check in the error handling path of `Execute()` |
+| `internal/command_resolver_test.go` | Modify | Add test cases for `-` prefix stripping, combined `-@`/`@-` prefixes, double-dash, dash in middle of line, multi-line continuation with dash |
+| `internal/executor_test.go` | Modify | Add test cases for `IgnoreError` behavior: ignored exit codes, combined with `Silent`, error propagation when `IgnoreError=false` |
+| `examples/*.Opsfile` | Modify | Add example command demonstrating `-` prefix usage |
+| `docs/feature-command-execution.md` | Modify | Document `-` prefix behavior and interaction with `@` and `--dry-run` |
+| `docs/feature-at-prefix-suppress.md` | Modify | Add note about combined `-@`/`@-` prefix support |
+
+---
+
+## 5. Alternatives Considered
+
+### Alternative A: Handle `-` Prefix in the Executor Only
+
+**Description:** Pass the `-` prefix through the resolver untouched. Have the executor check for and strip `-` before running the command.
+
+**Pros:**
+- Minimal changes to resolver -- only executor changes
+- No new fields on `ResolvedLine`
+
+**Cons:**
+- Executor must understand Opsfile syntax -- breaks separation of concerns
+- `--dry-run` output would include `-` prefix (confusing for users)
+- Inconsistent with how `@` prefix is handled (stripped in resolver)
+- Combined prefix handling becomes messy -- executor needs to know about both `@` and `-`
+
+**Why not chosen:** Violates the established architecture. The `@` prefix set the precedent: Opsfile syntax is resolved in the resolver, not the executor.
+
+---
+
+### Alternative B: Shell-Level Error Suppression
+
+**Description:** Instead of stripping `-` and handling it in Go, prepend the command with `|| true` or wrap it in a subshell that ignores errors.
+
+**Pros:**
+- No changes to executor error handling
+- Leverages shell behavior directly
+
+**Cons:**
+- Modifies the command text -- changes what gets echoed and what appears in dry-run
+- `|| true` changes the exit code to 0, which may mask errors in unexpected ways
+- Subshell wrapping changes the execution context (e.g., variable scope, directory)
+- Not consistent with Make's approach (which handles `-` at the runner level, not shell level)
+
+**Why not chosen:** Altering command text is surprising to users and creates subtle behavioral differences. The Go-level approach is cleaner and matches Make's implementation strategy.
+
+---
+
+### Alternative C: New Field on `OpsCommand` (Parser-Level)
+
+**Description:** Detect `-` during parsing in `opsfile_parser.go` and store it as metadata on the parsed command lines, similar to how an AST might work.
+
+**Pros:**
+- Earliest possible detection of prefix
+
+**Cons:**
+- Requires changing `OpsCommand.Environments` from `map[string][]string` to a more complex type
+- Large blast radius -- every consumer of `OpsCommand` must adapt
+- Inconsistent with how `@` was implemented (resolver, not parser)
+- The parser's job is to collect raw lines; semantic interpretation belongs in the resolver
+
+**Why not chosen:** Same reasoning as Alternative A in the `@` prefix design doc. The parser stores raw text; the resolver interprets syntax.
+
+---
+
+## Open Questions
+- [ ] Should stderr from an ignored-error line be visually differentiated (e.g., dimmed or prefixed with a warning)? Current proposal: no -- stderr passes through unchanged, matching Make behavior.
+
+---
+
+## 6. Task Breakdown
+
+### Phase 1: Foundation
+- [ ] Add `IgnoreError bool` field to `ResolvedLine` in `internal/command_resolver.go`
+- [ ] Refactor prefix stripping in `Resolve()` from single `@` check to loop handling both `@` and `-`
+- [ ] Write resolver unit tests for `-` prefix: stripping, combined `-@`/`@-`, double-dash, dash-only, dash in middle of line
+- [ ] Write resolver unit tests for multi-line continuation with `-` prefix (backslash and indent)
+
+### Phase 2: Integration
+- [ ] Add `IgnoreError` check to `Execute()` error path in `internal/executor.go`
+- [ ] Write executor unit tests: ignored exit code continues, non-ignored exit code still fails, combined `Silent`+`IgnoreError`, `IgnoreError` with invalid shell
+- [ ] Verify `--dry-run` output strips `-` prefix (covered by existing dry-run path since resolver already strips it)
+
+### Phase 3: Polish
+- [ ] Add `-` prefix example to an example Opsfile in `examples/`
+- [ ] Update `docs/feature-command-execution.md` with `-` prefix behavior
+- [ ] Update `docs/feature-at-prefix-suppress.md` with combined prefix note
+- [ ] Run `make lint` and `make test` for final validation
+
+---

--- a/docs/feat-dash-prefix-silent-failure.md
+++ b/docs/feat-dash-prefix-silent-failure.md
@@ -162,12 +162,14 @@ if err := cmd.Run(); err != nil {
 }
 ```
 
-When `line.IgnoreError` is true, the error is discarded and execution continues:
+When `line.IgnoreError` is true, only `*exec.ExitError` (non-zero exit code) is ignored — system-level errors such as shell-not-found or permission-denied still propagate. This matches Make's `-` behavior, which only suppresses exit code failures, not execution failures:
 ```go
 if err := cmd.Run(); err != nil {
-    if !line.IgnoreError {
-        return fmt.Errorf("running %q: %w", line.Text, err)
+    var exitErr *exec.ExitError
+    if line.IgnoreError && errors.As(err, &exitErr) {
+        continue // non-zero exit code ignored per - prefix
     }
+    return fmt.Errorf("running %q: %w", line.Text, err)
 }
 ```
 
@@ -300,7 +302,10 @@ main.go
 ---
 
 ## Open Questions
-- [ ] Should stderr from an ignored-error line be visually differentiated (e.g., dimmed or prefixed with a warning)? Current proposal: no -- stderr passes through unchanged, matching Make behavior.
+- [x] Should stderr from an ignored-error line be visually differentiated (e.g., dimmed or prefixed with a warning)? **No** — stderr passes through unchanged, matching Make behavior.
+- [x] What happens with `-@-` or `@-@`? The loop consumes at most one `-` and one `@`. `-@-` strips one `-` and one `@`, leaving `-` as shell text. `@-@` strips one `@` and one `-`, leaving `@` as shell text. Both are correct and deterministic; a test case covers this.
+- [x] How does `-` prefix interact with `CommandArgs` passthrough? `CommandArgs` are appended at the shell invocation level after the resolver runs. Since `-` is stripped in the resolver and `IgnoreError` is metadata on `ResolvedLine`, there is no interaction. A test case validates this.
+- [x] Should system-level errors (shell not found, permission denied) be suppressed by `-`? **No** — only `*exec.ExitError` is ignored. `errors.As(err, &exitErr)` ensures non-exit errors always propagate.
 
 ---
 

--- a/docs/testplans/testplan-dash-prefix-silent-failure.md
+++ b/docs/testplans/testplan-dash-prefix-silent-failure.md
@@ -1,0 +1,159 @@
+# Test Plan: `-` Prefix to Ignore Non-Zero Exit Codes
+
+**Feature Doc:** [docs/feat-dash-prefix-silent-failure.md](../feat-dash-prefix-silent-failure.md)
+
+---
+
+## 1. Scope
+
+### In Scope
+- `-` prefix detection and stripping in the command resolver
+- `IgnoreError` field on `ResolvedLine` struct
+- Executor error suppression when `IgnoreError` is true
+- Combined `-@` and `@-` prefix handling (order-independent)
+- Multi-line continuation with `-` prefix (backslash and indent)
+- `--dry-run` compatibility (prints resolved lines with `-` already stripped)
+- Variable substitution on lines with `-` prefix
+- Regression testing for existing `@` prefix, resolver, and executor behavior
+
+### Out of Scope
+- Suppressing stderr output from the failing command
+- Applying `-` to an entire command block via a single annotation
+- Retry logic or conditional execution based on exit codes
+
+---
+
+## 2. Test Objectives
+
+- Verify that `-` prefix is correctly stripped from resolved command lines and `IgnoreError` is set to true
+- Verify that the executor ignores non-zero exit codes when `IgnoreError` is true and continues to the next line
+- Verify that commands without `-` still fail-fast on non-zero exit codes (no regression)
+- Verify combined `-@` and `@-` prefixes work in either order, setting both `Silent` and `IgnoreError`
+- Verify `--dry-run` prints resolved lines with `-` already stripped
+- Verify no regressions in existing `@` prefix behavior or executor error handling
+
+---
+
+## 3. Entry & Exit Criteria
+
+### Entry Criteria (prerequisites before testing begins)
+- [ ] Feature implementation is code-complete
+- [ ] Code compiles without errors (`make build`)
+- [ ] Existing tests still pass (`make test`)
+
+### Exit Criteria (conditions to consider testing complete)
+- [ ] All green path automated tests pass
+- [ ] All red path automated tests pass
+- [ ] All green/red manual tests have been run and pass
+- [ ] No regressions in related features
+- [ ] Test coverage does not decrease
+
+### Acceptance Criteria
+
+- [ ] Lines with `-` prefix have `IgnoreError: true` and `-` is stripped from the command text
+- [ ] Executor continues to the next line when a `-` prefixed command returns non-zero
+- [ ] Executor still returns an error for non-zero exit codes on lines without `-` prefix
+- [ ] `-@` and `@-` both set `Silent: true` AND `IgnoreError: true`, with both prefix characters stripped
+- [ ] `--cmd` strips one `-` and passes `-cmd` as shell text (single-layer stripping, consistent with `@@`)
+- [ ] `-` in the middle of a line (e.g., `kubectl delete --force`) is not treated as Opsfile syntax
+- [ ] `--dry-run` shows resolved commands without `-` prefix
+- [ ] Multi-line commands with `-` on the first fragment inherit `IgnoreError` for the entire joined command
+- [ ] Variable substitution works correctly on `-`-prefixed lines
+- [ ] No breaking changes to existing `@` prefix behavior or fail-fast error handling
+
+---
+
+## 4. Green Path Tests
+
+| Short Title | Test Name | Input / Setup | Expected Outcome | Type |
+|---|---|---|---|---|
+| Basic - strip | TestResolve_DashPrefixStripped | Opsfile line: `-echo hello` | `ResolvedLine{Text: "echo hello", IgnoreError: true, Silent: false}` | automated (unit) |
+| No - prefix | TestResolve_NoDashPrefix | Opsfile line: `echo hello` | `ResolvedLine{Text: "echo hello", IgnoreError: false, Silent: false}` | automated (unit) |
+| Combined -@ prefix | TestResolve_DashAtPrefix | Opsfile line: `-@echo hello` | `ResolvedLine{Text: "echo hello", IgnoreError: true, Silent: true}` | automated (unit) |
+| Combined @- prefix | TestResolve_AtDashPrefix | Opsfile line: `@-echo hello` | `ResolvedLine{Text: "echo hello", IgnoreError: true, Silent: true}` | automated (unit) |
+| - with variable sub | TestResolve_DashPrefixWithVariable | `-echo $(VAR)` with `VAR=hello` | `ResolvedLine{Text: "echo hello", IgnoreError: true}` | automated (unit) |
+| - with env-scoped var | TestResolve_DashPrefixWithScopedVariable | `-echo $(ACCT)` with `prod_ACCT=123` | `ResolvedLine{Text: "echo 123", IgnoreError: true}` | automated (unit) |
+| - with backslash cont. | TestResolve_DashPrefixWithBackslashContinuation | `-aws logs \` / `--follow` | Single `ResolvedLine{Text: "aws logs --follow", IgnoreError: true}` | automated (unit) |
+| - with indent cont. | TestResolve_DashPrefixWithIndentContinuation | `-aws logs` / (indented) `--follow` | Single `ResolvedLine{Text: "aws logs --follow", IgnoreError: true}` | automated (unit) |
+| Executor ignores error | TestExecute_IgnoreErrorContinues | `ResolvedLine{Text: "false", IgnoreError: true}` then `ResolvedLine{Text: "true"}` | No error returned, both lines execute | automated (unit) |
+| Executor ignores non-zero exit | TestExecute_IgnoreErrorExitCode42 | `ResolvedLine{Text: "exit 42", IgnoreError: true}` | No error returned | automated (unit) |
+| Mixed - and non- lines | TestResolve_MixedDashAndNonDash | Lines: `-docker stop app`, `docker run app` | First IgnoreError=true, second IgnoreError=false | automated (unit) |
+| - with @ mixed lines | TestResolve_MultiLineMixedDashAt | Lines: `-@echo setup`, `echo deploy`, `-echo cleanup` | Three lines with correct Silent/IgnoreError flags | automated (unit) |
+| IgnoreError + Silent combined | TestExecute_IgnoreErrorAndSilent | `ResolvedLine{Text: "false", IgnoreError: true, Silent: true}` | No echo, no error, execution continues | automated (unit) |
+| Dry-run with - | DryRunDashPrefix | `-docker stop app` with `--dry-run` | Prints `docker stop app` (- stripped) | manual verification |
+
+---
+
+## 5. Red Path Tests
+
+| Short Title | Test Name | Input / Setup | Expected Outcome | Type |
+|---|---|---|---|---|
+| Non-dash line still fails | TestExecute_NonDashLineStillFails | `ResolvedLine{Text: "false", IgnoreError: false}` | Error returned with exit code 1 | automated (unit) |
+| IgnoreError + invalid shell | TestExecute_IgnoreErrorInvalidShell | `ResolvedLine{Text: "echo hi", IgnoreError: true}`, invalid shell path | Error returned (shell binary not found cannot be ignored -- it's not a command exit code) | automated (unit) |
+| - with missing variable | TestResolve_DashPrefixMissingVariable | `-echo $(MISSING)` | Error: variable not defined (resolver error, not execution) | automated (unit) |
+| Fail-fast after ignored error | TestExecute_FailAfterIgnored | `{Text: "false", IgnoreError: true}`, then `{Text: "false", IgnoreError: false}` | First error ignored, second causes failure with exit code 1 | automated (unit) |
+
+---
+
+## 6. Edge Cases & Boundary Conditions
+
+| Short Title | Test Name | Input / Setup | Expected Outcome | Type |
+|---|---|---|---|---|
+| Double -- prefix | TestResolve_DoubleDashPrefix | `--echo hello` | `ResolvedLine{Text: "-echo hello", IgnoreError: true}` -- one `-` stripped, one remains as shell text | automated (unit) |
+| - only (no command) | TestResolve_DashPrefixOnly | Line is just `-` | `ResolvedLine{Text: "", IgnoreError: true, Silent: false}` -- empty command | automated (unit) |
+| -@ only (no command) | TestResolve_DashAtPrefixOnly | Line is just `-@` | `ResolvedLine{Text: "", IgnoreError: true, Silent: true}` | automated (unit) |
+| - in middle of line | TestResolve_DashInMiddleOfLine | `kubectl delete --force` | `ResolvedLine{Text: "kubectl delete --force", IgnoreError: false}` -- only leading - is special | automated (unit) |
+| - in variable value | TestResolve_DashInVariableValue | `VAR=hello-world`, line: `echo $(VAR)` | `ResolvedLine{Text: "echo hello-world", IgnoreError: false}` | automated (unit) |
+| - on continuation (not first) | TestResolve_DashOnContinuationFragment | `aws logs \` / `-follow` | `-` on non-first fragment is shell text: `ResolvedLine{Text: "aws logs -follow", IgnoreError: false}` | automated (unit) |
+| @ still works alone | TestResolve_AtPrefixStillWorks | `@echo hello` | `ResolvedLine{Text: "echo hello", Silent: true, IgnoreError: false}` -- regression check | automated (unit) |
+| IgnoreError on command-not-found | TestExecute_IgnoreErrorCommandNotFound | `ResolvedLine{Text: "nonexistent-binary-xyz", IgnoreError: true}` | Error is ignored, execution continues (shell returns 127 for command not found) | automated (unit) |
+| IgnoreError with global silent | TestExecute_IgnoreErrorWithGlobalSilent | `ResolvedLine{Text: "false", IgnoreError: true}`, global silent=true | No echo, no error, execution continues | automated (unit) |
+| All lines IgnoreError | TestExecute_AllLinesIgnoreError | Multiple failing lines all with IgnoreError=true | No error returned, all lines attempted | automated (unit) |
+| IgnoreError echo still shows | TestExecute_IgnoreErrorEchoStillShows | `ResolvedLine{Text: "false", IgnoreError: true, Silent: false}`, global silent=false | Line is echoed before execution, error is ignored | automated (unit) |
+| Empty lines list | TestExecute_EmptyLinesUnchanged | Empty `[]ResolvedLine{}` | No error, no output (regression check) | automated (unit) |
+| -@ with backslash cont. | TestResolve_DashAtWithBackslashContinuation | `-@aws stop \` / `--force` | Single `ResolvedLine{Text: "aws stop --force", IgnoreError: true, Silent: true}` | automated (unit) |
+| - with whitespace after | TestResolve_DashPrefixWhitespaceAfter | Line: `-   ` (- followed by spaces) | `ResolvedLine{Text: "   ", IgnoreError: true}` | automated (unit) |
+
+---
+
+## 9. Existing Automated Tests
+
+- `TestResolve_AtPrefixStripped` in `internal/command_resolver_test.go` (line 499) -- validates `@` stripping; must still pass after refactoring prefix loop
+- `TestResolve_MixedAtAndNonAt` in `internal/command_resolver_test.go` (line 525) -- validates mixed `@` and non-`@` lines
+- `TestResolve_DoubleAtPrefix` in `internal/command_resolver_test.go` (line 600) -- validates `@@` strips one `@`; must still pass with loop-based stripping
+- `TestResolve_AtPrefixWithBackslashContinuation` in `internal/command_resolver_test.go` (line 572) -- validates `@` with backslash continuation
+- `TestResolve_AtOnContinuationFragment` in `internal/command_resolver_test.go` (line 711) -- validates `@` on non-first fragment is shell text
+- `TestExecute` in `internal/executor_test.go` (line 23) -- 7 subtests for basic execution and error handling; must still pass
+- `TestExecute_ErrorWrapsCommandString` in `internal/executor_test.go` (line 83) -- validates error wrapping
+- `TestExecute_EchoesNonSilentLine` in `internal/executor_test.go` (line 107) -- validates echo behavior
+- `TestExecute_SkipsSilentLine` in `internal/executor_test.go` (line 116) -- validates silent echo suppression
+- `TestExecute_GlobalSilentSuppressesAll` in `internal/executor_test.go` (line 125) -- validates `--silent` flag
+- `TestExecute_AtPrefixOnFailingCommand` in `internal/executor_test.go` (line 156) -- validates `@` on a failing command still propagates error
+
+---
+
+## 10. Missing Automated Tests
+
+| Scenario | Type | What It Validates |
+|---|---|---|
+| `-` prefix stripped and `IgnoreError` flag set in resolver | unit | Core `-` detection logic in refactored `Resolve()` prefix loop |
+| Combined `-@` and `@-` both produce `Silent=true, IgnoreError=true` | unit | Order-independent combined prefix handling |
+| `--` double prefix strips only one `-` | unit | FR-5: single-layer stripping, consistent with `@@` behavior |
+| `-` with variable substitution | unit | `-` stripped before `substituteVars()` is called |
+| `-` with backslash continuation | unit | Parser joins fragments, `-` on first fragment marks whole line IgnoreError |
+| `-` mid-line (e.g., `--force` flag) not stripped | unit | FR-6: only leading `-` is Opsfile syntax |
+| Executor continues after `IgnoreError=true` line fails | unit | Core ignore-error execution behavior |
+| Executor still fails on non-`IgnoreError` line failure | unit | Regression: fail-fast behavior unchanged for non-prefixed lines |
+| Executor handles IgnoreError + Silent combined | unit | Orthogonal concerns work together without interference |
+| `--dry-run` prints `line.Text` with `-` already stripped | e2e | FR-4: dry-run compatibility |
+| Existing `@` prefix tests pass with refactored loop | unit | Regression: `@` behavior unchanged after loop refactor |
+| Existing executor error tests pass with `IgnoreError` field | unit | Regression: fail-fast behavior unchanged when `IgnoreError=false` |
+| IgnoreError on invalid shell binary (not command exit) | unit | Clarify behavior: shell-not-found errors may or may not be ignorable |
+
+---
+
+## Notes
+- **IgnoreError on invalid shell path**: The design doc proposes `if !line.IgnoreError { return error }` which would ignore ALL errors including shell-binary-not-found. The implementation should clarify whether `IgnoreError` only ignores `*exec.ExitError` (command returned non-zero) or all errors from `cmd.Run()` (including shell not found, permission denied). Recommendation: only ignore `*exec.ExitError` to match Make behavior, where `-` ignores the command's exit code but not system-level failures. This is a potential design gap worth discussing.
+- **Prefix stripping loop correctness**: The proposed loop handles `@-`, `-@`, `@`, `-`, and bare lines. Verify that the loop terminates correctly for inputs like `-@-` (should strip one `-` and one `@`, leaving `-` as shell text) and `@-@` (should strip one `@` and one `-`, leaving `@` as shell text).
+- **Regression risk**: The refactoring of the prefix stripping from a single `if strings.HasPrefix(line, "@")` to a loop changes existing behavior for `@` prefix detection. All 20+ existing `@` tests must continue passing without modification to confirm no regression.
+- **`toLines` test helper**: The existing `toLines()` helper in `executor_test.go` creates `ResolvedLine` with `Silent=false`. It should be verified that it also defaults `IgnoreError` to `false` (Go zero-value should handle this, but worth a quick check).

--- a/examples/Opsfile
+++ b/examples/Opsfile
@@ -57,3 +57,14 @@ list-instance-ips:
             --region $(AWS_REGION) \
             --query "taskArns" \
             --output text
+
+
+# Redeploy the service container.
+# The - prefix ignores errors from stop/rm if the container isn't running.
+# The -@ prefix also suppresses echo output for the cleanup lines.
+redeploy:
+    local:
+        -@docker stop my-service
+        -@docker rm my-service
+        docker run -d --name my-service my-image
+        @echo "Redeployment complete"

--- a/internal/command_resolver.go
+++ b/internal/command_resolver.go
@@ -9,9 +9,12 @@ import (
 // ResolvedLine holds a single shell line after resolution, with per-line
 // metadata. Silent is true when the original Opsfile line had a leading @
 // prefix, indicating that the executor should not echo it before running.
+// IgnoreError is true when the original Opsfile line had a leading - prefix,
+// indicating that the executor should ignore non-zero exit codes for this line.
 type ResolvedLine struct {
-	Text   string
-	Silent bool
+	Text        string
+	Silent      bool
+	IgnoreError bool
 }
 
 // ResolvedCommand holds the shell lines for a command after environment
@@ -46,15 +49,29 @@ func Resolve(commandName, env string, commands map[string]OpsCommand, vars OpsVa
 	lines := make([]ResolvedLine, 0, len(raw))
 	for _, line := range raw {
 		silent := false
-		if strings.HasPrefix(line, "@") {
-			silent = true
-			line = line[1:]
+		ignoreError := false
+		for len(line) > 0 {
+			switch line[0] {
+			case '@':
+				if !silent {
+					silent = true
+					line = line[1:]
+					continue
+				}
+			case '-':
+				if !ignoreError {
+					ignoreError = true
+					line = line[1:]
+					continue
+				}
+			}
+			break
 		}
 		substituted, err := substituteVars(line, env, vars)
 		if err != nil {
 			return ResolvedCommand{}, err
 		}
-		lines = append(lines, ResolvedLine{Text: substituted, Silent: silent})
+		lines = append(lines, ResolvedLine{Text: substituted, Silent: silent, IgnoreError: ignoreError})
 	}
 	return ResolvedCommand{Lines: lines}, nil
 }

--- a/internal/command_resolver_test.go
+++ b/internal/command_resolver_test.go
@@ -754,3 +754,307 @@ deploy:
 		assert.False(t, line.Silent, "line %d should not be silent", i)
 	}
 }
+
+// --- - (dash) prefix tests ---
+
+func TestResolve_DashPrefixStripped(t *testing.T) {
+	commands := map[string]OpsCommand{
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
+			"prod": {"-echo hello"},
+		}},
+	}
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "echo hello", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].IgnoreError)
+	assert.False(t, got.Lines[0].Silent)
+}
+
+func TestResolve_NoDashPrefix(t *testing.T) {
+	commands := map[string]OpsCommand{
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
+			"prod": {"echo hello"},
+		}},
+	}
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "echo hello", got.Lines[0].Text)
+	assert.False(t, got.Lines[0].IgnoreError)
+	assert.False(t, got.Lines[0].Silent)
+}
+
+func TestResolve_DashAtPrefix(t *testing.T) {
+	commands := map[string]OpsCommand{
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
+			"prod": {"-@echo hello"},
+		}},
+	}
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "echo hello", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].IgnoreError)
+	assert.True(t, got.Lines[0].Silent)
+}
+
+func TestResolve_AtDashPrefix(t *testing.T) {
+	commands := map[string]OpsCommand{
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
+			"prod": {"@-echo hello"},
+		}},
+	}
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "echo hello", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].IgnoreError)
+	assert.True(t, got.Lines[0].Silent)
+}
+
+func TestResolve_DashPrefixWithVariable(t *testing.T) {
+	vars, commands := parseFixture(t, `
+VAR=hello
+
+my-cmd:
+    default:
+        -echo $(VAR)
+`)
+	got, err := Resolve("my-cmd", "prod", commands, vars)
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "echo hello", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].IgnoreError)
+}
+
+func TestResolve_DashPrefixWithScopedVariable(t *testing.T) {
+	vars, commands := parseFixture(t, `
+prod_ACCT=123
+
+my-cmd:
+    default:
+        -echo $(ACCT)
+`)
+	got, err := Resolve("my-cmd", "prod", commands, vars)
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "echo 123", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].IgnoreError)
+}
+
+func TestResolve_DashPrefixWithBackslashContinuation(t *testing.T) {
+	vars, commands := parseFixture(t, `
+my-cmd:
+    prod:
+        -aws logs \
+            --follow
+`)
+	got, err := Resolve("my-cmd", "prod", commands, vars)
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "aws logs --follow", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].IgnoreError)
+}
+
+func TestResolve_DashPrefixWithIndentContinuation(t *testing.T) {
+	vars, commands := parseFixture(t, `
+my-cmd:
+    prod:
+        -aws logs
+            --follow
+`)
+	got, err := Resolve("my-cmd", "prod", commands, vars)
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "aws logs --follow", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].IgnoreError)
+}
+
+func TestResolve_MixedDashAndNonDash(t *testing.T) {
+	commands := map[string]OpsCommand{
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
+			"prod": {"-docker stop app", "docker run app"},
+		}},
+	}
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 2)
+	assert.Equal(t, "docker stop app", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].IgnoreError)
+	assert.Equal(t, "docker run app", got.Lines[1].Text)
+	assert.False(t, got.Lines[1].IgnoreError)
+}
+
+func TestResolve_MultiLineMixedDashAt(t *testing.T) {
+	vars, commands := parseFixture(t, `
+my-cmd:
+    prod:
+        -@echo setup
+        echo deploy
+        -echo cleanup
+`)
+	got, err := Resolve("my-cmd", "prod", commands, vars)
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 3)
+
+	wantTexts := []string{"echo setup", "echo deploy", "echo cleanup"}
+	wantSilent := []bool{true, false, false}
+	wantIgnoreError := []bool{true, false, true}
+	assert.Equal(t, wantTexts, lineTexts(got))
+	for i, line := range got.Lines {
+		assert.Equal(t, wantSilent[i], line.Silent, "line %d Silent", i)
+		assert.Equal(t, wantIgnoreError[i], line.IgnoreError, "line %d IgnoreError", i)
+	}
+}
+
+func TestResolve_DoubleDashPrefix(t *testing.T) {
+	commands := map[string]OpsCommand{
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
+			"prod": {"--echo hello"},
+		}},
+	}
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "-echo hello", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].IgnoreError)
+}
+
+func TestResolve_DashPrefixOnly(t *testing.T) {
+	commands := map[string]OpsCommand{
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
+			"prod": {"-"},
+		}},
+	}
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].IgnoreError)
+	assert.False(t, got.Lines[0].Silent)
+}
+
+func TestResolve_DashAtPrefixOnly(t *testing.T) {
+	commands := map[string]OpsCommand{
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
+			"prod": {"-@"},
+		}},
+	}
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].IgnoreError)
+	assert.True(t, got.Lines[0].Silent)
+}
+
+func TestResolve_DashInMiddleOfLine(t *testing.T) {
+	commands := map[string]OpsCommand{
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
+			"prod": {"kubectl delete --force"},
+		}},
+	}
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "kubectl delete --force", got.Lines[0].Text)
+	assert.False(t, got.Lines[0].IgnoreError)
+}
+
+func TestResolve_DashInVariableValue(t *testing.T) {
+	vars, commands := parseFixture(t, `
+VAR=hello-world
+
+my-cmd:
+    default:
+        echo $(VAR)
+`)
+	got, err := Resolve("my-cmd", "prod", commands, vars)
+	require.NoError(t, err)
+	assert.Equal(t, "echo hello-world", got.Lines[0].Text)
+	assert.False(t, got.Lines[0].IgnoreError)
+}
+
+func TestResolve_DashOnContinuationFragment(t *testing.T) {
+	vars, commands := parseFixture(t, `
+my-cmd:
+    prod:
+        aws logs \
+            -follow
+`)
+	got, err := Resolve("my-cmd", "prod", commands, vars)
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "aws logs -follow", got.Lines[0].Text)
+	assert.False(t, got.Lines[0].IgnoreError)
+}
+
+func TestResolve_DashPrefixMissingVariable(t *testing.T) {
+	commands := map[string]OpsCommand{
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
+			"prod": {"-echo $(MISSING)"},
+		}},
+	}
+	_, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "not defined")
+}
+
+func TestResolve_DashPrefixWhitespaceAfter(t *testing.T) {
+	commands := map[string]OpsCommand{
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
+			"prod": {"-   "},
+		}},
+	}
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "   ", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].IgnoreError)
+}
+
+func TestResolve_DashAtWithBackslashContinuation(t *testing.T) {
+	vars, commands := parseFixture(t, `
+my-cmd:
+    prod:
+        -@aws stop \
+            --force
+`)
+	got, err := Resolve("my-cmd", "prod", commands, vars)
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "aws stop --force", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].IgnoreError)
+	assert.True(t, got.Lines[0].Silent)
+}
+
+func TestResolve_DashAtDashPrefix(t *testing.T) {
+	// -@- should strip one - and one @, leaving - as shell text
+	commands := map[string]OpsCommand{
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
+			"prod": {"-@-echo hello"},
+		}},
+	}
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "-echo hello", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].IgnoreError)
+	assert.True(t, got.Lines[0].Silent)
+}
+
+func TestResolve_AtDashAtPrefix(t *testing.T) {
+	// @-@ should strip one @ and one -, leaving @ as shell text
+	commands := map[string]OpsCommand{
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
+			"prod": {"@-@echo hello"},
+		}},
+	}
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{})
+	require.NoError(t, err)
+	require.Len(t, got.Lines, 1)
+	assert.Equal(t, "@echo hello", got.Lines[0].Text)
+	assert.True(t, got.Lines[0].IgnoreError)
+	assert.True(t, got.Lines[0].Silent)
+}

--- a/internal/executor.go
+++ b/internal/executor.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -16,7 +17,11 @@ import (
 // Opsfile). When silent is true, no lines are echoed regardless of per-line
 // flags.
 //
-// Returns immediately on the first command failure.
+// When a line's IgnoreError flag is set (from a - prefix in the Opsfile),
+// non-zero exit codes from that line are ignored and execution continues.
+// System-level errors (e.g., shell not found) still propagate.
+//
+// Returns immediately on the first non-ignored command failure.
 func Execute(lines []ResolvedLine, shell string, silent bool, echo io.Writer) error {
 	for _, line := range lines {
 		if !silent && !line.Silent {
@@ -27,6 +32,10 @@ func Execute(lines []ResolvedLine, shell string, silent bool, echo io.Writer) er
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
+			var exitErr *exec.ExitError
+			if line.IgnoreError && errors.As(err, &exitErr) {
+				continue
+			}
 			return fmt.Errorf("running %q: %w", line.Text, err)
 		}
 	}

--- a/internal/executor_test.go
+++ b/internal/executor_test.go
@@ -180,3 +180,95 @@ func TestExecute_EmptyLinesWithSilent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, buf.String())
 }
+
+// --- IgnoreError behavior tests ---
+
+func TestExecute_IgnoreErrorContinues(t *testing.T) {
+	var buf bytes.Buffer
+	err := Execute([]ResolvedLine{
+		{Text: "false", IgnoreError: true},
+		{Text: "true"},
+	}, "/bin/sh", false, &buf)
+	require.NoError(t, err)
+	assert.Equal(t, "false\ntrue\n", buf.String())
+}
+
+func TestExecute_IgnoreErrorExitCode42(t *testing.T) {
+	err := Execute([]ResolvedLine{
+		{Text: "exit 42", IgnoreError: true},
+	}, "/bin/sh", false, io.Discard)
+	assert.NoError(t, err)
+}
+
+func TestExecute_NonDashLineStillFails(t *testing.T) {
+	err := Execute([]ResolvedLine{
+		{Text: "false", IgnoreError: false},
+	}, "/bin/sh", false, io.Discard)
+	require.Error(t, err)
+	var exitErr *exec.ExitError
+	require.True(t, errors.As(err, &exitErr))
+	assert.Equal(t, 1, exitErr.ExitCode())
+}
+
+func TestExecute_IgnoreErrorInvalidShell(t *testing.T) {
+	err := Execute([]ResolvedLine{
+		{Text: "echo hi", IgnoreError: true},
+	}, "/nonexistent/shell/binary", false, io.Discard)
+	require.Error(t, err, "system-level error (shell not found) should not be ignored")
+}
+
+func TestExecute_FailAfterIgnored(t *testing.T) {
+	err := Execute([]ResolvedLine{
+		{Text: "false", IgnoreError: true},
+		{Text: "false", IgnoreError: false},
+	}, "/bin/sh", false, io.Discard)
+	require.Error(t, err)
+	var exitErr *exec.ExitError
+	require.True(t, errors.As(err, &exitErr))
+	assert.Equal(t, 1, exitErr.ExitCode())
+}
+
+func TestExecute_IgnoreErrorAndSilent(t *testing.T) {
+	var buf bytes.Buffer
+	err := Execute([]ResolvedLine{
+		{Text: "false", IgnoreError: true, Silent: true},
+	}, "/bin/sh", false, &buf)
+	require.NoError(t, err)
+	assert.Empty(t, buf.String())
+}
+
+func TestExecute_IgnoreErrorWithGlobalSilent(t *testing.T) {
+	var buf bytes.Buffer
+	err := Execute([]ResolvedLine{
+		{Text: "false", IgnoreError: true},
+	}, "/bin/sh", true, &buf)
+	require.NoError(t, err)
+	assert.Empty(t, buf.String())
+}
+
+func TestExecute_AllLinesIgnoreError(t *testing.T) {
+	err := Execute([]ResolvedLine{
+		{Text: "false", IgnoreError: true},
+		{Text: "exit 2", IgnoreError: true},
+		{Text: "exit 127", IgnoreError: true},
+	}, "/bin/sh", false, io.Discard)
+	assert.NoError(t, err)
+}
+
+func TestExecute_IgnoreErrorEchoStillShows(t *testing.T) {
+	var buf bytes.Buffer
+	err := Execute([]ResolvedLine{
+		{Text: "false", IgnoreError: true, Silent: false},
+	}, "/bin/sh", false, &buf)
+	require.NoError(t, err)
+	assert.Equal(t, "false\n", buf.String())
+}
+
+func TestExecute_IgnoreErrorCommandNotFound(t *testing.T) {
+	// Shell returns exit code 127 for command not found — this is an ExitError,
+	// so it should be ignored when IgnoreError is true.
+	err := Execute([]ResolvedLine{
+		{Text: "nonexistent-binary-xyz-12345", IgnoreError: true},
+	}, "/bin/sh", false, io.Discard)
+	assert.NoError(t, err)
+}

--- a/internal/opsfile_parser_test.go
+++ b/internal/opsfile_parser_test.go
@@ -84,7 +84,7 @@ func TestParseOpsFile_Commands(t *testing.T) {
 	_, commands, _, _, err := ParseOpsFile(examplesOpsfile(t))
 	require.NoError(t, err)
 
-	expectedCommands := []string{"tail-logs", "list-instance-ips", "show-profile"}
+	expectedCommands := []string{"tail-logs", "list-instance-ips", "show-profile", "redeploy"}
 	for _, name := range expectedCommands {
 		cmd, ok := commands[name]
 		require.True(t, ok, "command %q not found", name)


### PR DESCRIPTION
## Key Changes

- Add `IgnoreError bool` field to `ResolvedLine` in `internal/command_resolver.go`
- Replace single `@` prefix check in `Resolve()` with a loop that handles `@`, `-`, `-@`, `@-` in any order (at most one of each consumed)
- Add `IgnoreError` check in `internal/executor.go` — uses `errors.As(err, &exitErr)` with `*exec.ExitError` so only non-zero exit codes are ignored; system-level errors (shell not found, permission denied) still propagate
- Add `redeploy` example command to `examples/Opsfile` demonstrating `-` and `-@` prefixes
- Add design doc at `docs/feat-dash-prefix-silent-failure.md` and test plan at `docs/testplans/testplan-dash-prefix-silent-failure.md`

## Why do we need this?

Closes #20. Ops currently stops on the first shell line that returns a non-zero exit code. Some operations (e.g. `docker stop`, `rm -f`, `killall`) may legitimately fail without indicating a real problem. This adds Makefile-style `-` prefix support so users can mark individual lines as failure-tolerant, allowing execution to continue to the next line.

## New modules or other dependencies introduced

None. Uses `errors.As` from the standard library (already imported).

## How was this tested?

- 20 new unit tests in `internal/command_resolver_test.go` covering: `-` stripping, combined `-@`/`@-`, `--` (double-dash), `-@-`/`@-@` edge cases, dash in middle of line, dash in variable values, multi-line continuation, whitespace after dash
- 9 new unit tests in `internal/executor_test.go` covering: ignored exit codes, system errors still propagate (`invalid shell` test), combined `IgnoreError`+`Silent`, all-lines `IgnoreError`, exit code 127 ignored
- `internal/opsfile_parser_test.go` updated for new `redeploy` example command
- All existing `@` prefix tests (20+) pass with the refactored loop-based prefix stripping
- `make lint` and `make test` pass cleanly