### PR TITLE
feat: add Claude Code plugin with /ops:run and /ops:init-opsfile skills

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "ops",
+  "version": "1.0.0",
+  "description": "Claude skills for the ops CLI — run on-call. live-ops commands by name or natural language, and generate new Opsfiles",
+  "author": {
+    "name": "seanseannery",
+    "url": "https://github.com/seanseannery/opsfile"
+  },
+  "homepage": "https://github.com/seanseannery/opsfile",
+  "repository": "https://github.com/seanseannery/opsfile",
+  "license": "MIT",
+  "keywords": ["ops", "opsfile", "devops", "operations", "runbook", "cli"],
+  "skills": "./skills/",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "command -v ops > /dev/null 2>&1 || echo 'opsfile plugin: ops CLI not found. Install it at https://github.com/seanseannery/opsfile'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,10 @@
     ├── .github/              Github Actions and PR/Issue templates
     ├────── workflows/        GitHub Actions workflows definitions (release, PR checks) and cliff.toml changelog config
     ├── .githooks/            Local git hooks: pre-push (lint+test), commit-msg (conventional commit format)
+    ├── .claude-plugin/       Claude Code plugin manifest (plugin.json)
+    ├── skills/               Claude Code plugin skills
+    ├────── run/              /ops:run skill — run ops commands (direct or natural language)
+    ├────── init-opsfile/     /ops:init-opsfile skill — scaffold a new Opsfile from repo analysis
     │
     ├── Formula/              Homebrew tap formula — auto-updated by release.yml on each release
     ├── go.mod                Module declaration (sean_seannery/opsfile, Go 1.25+, no external deps)

--- a/README.md
+++ b/README.md
@@ -161,6 +161,40 @@
   >$> claude 'analyze my projects Opsfile and add a table of commands and supported environments to CLAUDE.md for operational debugging'
   >```
 
+## Claude Code Plugin
+
+The `opsfile` plugin for [Claude Code](https://claude.ai/code) adds two skills so you can run ops commands and scaffold Opsfiles directly from your AI assistant.
+
+### Install
+
+```
+/plugin marketplace add seanseannery/opsfile
+/plugin install ops@opsfile
+```
+
+### Skills
+
+#### `/ops:run` — Run ops commands
+
+Accepts direct CLI arguments **or** natural language:
+
+```
+/ops:run prod tail-logs
+/ops:run --list
+/ops:run tail the production logs and grep for errors
+/ops:run how many instances are running in preprod?
+```
+
+When given natural language, the skill runs `ops --list` to discover available commands, resolves the best match, shows you the command it will run, then executes it.
+
+#### `/ops:init-opsfile` — Scaffold a new Opsfile
+
+Analyzes the current repo's tech stack (language, cloud platform, containerization) and generates a starter `Opsfile` using the platform-specific examples as templates. Asks for confirmation before writing.
+
+```
+/ops:init-opsfile
+```
+
 ## CONTRIBUTING
 
 For tips on how to set up dev environment, build, test, and how to follow PR and community best practices. Please read [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -16,6 +16,7 @@
       <nav class="site-nav">
         <a href="#install">Install</a>
         <a href="#usage">Usage</a>
+        <a href="#claude-plugin">Claude Plugin</a>
         <a href="https://github.com/seanseannery/opsfile">GitHub</a>
       </nav>
     </div>
@@ -25,10 +26,11 @@
   <section class="hero">
     <div class="container">
       <h1>Opsfile</h1>
-      <p class="tagline">Like <code>make</code>, but for common live ops commands</p>
-      <p class="subtitle">Create an Opsfile. Run <code>ops prod rollback-cluster</code>. Go back to sleep.</p>
+      <p class="tagline">Like <code>make</code>, but for common live-ops commands</p>
+      <p class="subtitle">Create an Opsfile. Run <code>ops prod rollback-cluster</code>. Go back to sleep. (or just have claude do it)</p>
       <div class="cta-buttons">
         <a href="#install" class="btn-primary">Install</a>
+        <a href="#features" class="btn-secondary">Features?</a>
         <a href="https://github.com/seanseannery/opsfile" class="btn-secondary">View on GitHub</a>
       </div>
 
@@ -52,6 +54,12 @@
           <div class="line">
             <span class="out">No alarms in ALARM state. All clear.</span>
           </div>
+          <div class="line">
+            <span class="prompt">$</span><span class="cmd"> claude "<span class="skill">/ops:run</span> are there any errors in staging?"</span>
+          </div>
+          <div class="line">
+            <span class="out">Running: ops staging error-rate → 0.04% (9 errors / 30 min)</span>
+          </div>
           <span class="cursor"></span>
         </div>
       </div>
@@ -66,19 +74,26 @@
         <button class="tab-btn" data-tab="tab-curl">curl</button>
         <button class="tab-btn" data-tab="tab-brew">Homebrew</button>
         <button class="tab-btn" data-tab="tab-npm">npm</button>
+        <button class="tab-btn" data-tab="tab-claude">Claude Plugin</button>
       </div>
 
       <div id="tab-curl" class="tab-content code-block">
-        <pre><code>curl -fsSL https://seanseannery.github.io/opsfile/install.sh | bash</code></pre>
+        <pre><code><span class="sh-cmd">curl</span> <span class="sh-varname">-fsSL</span> <span class="sh-val">https://seanseannery.github.io/opsfile/install.sh</span> <span class="sh-comment">|</span> <span class="sh-cmd">bash</span></code></pre>
       </div>
 
       <div id="tab-brew" class="tab-content code-block">
-        <pre><code>brew tap seanseannery/opsfile https://github.com/seanseannery/opsfile
-brew install seanseannery/opsfile/opsfile</code></pre>
+        <pre><code><span class="sh-cmd">brew</span> <span class="sh-env">tap</span> <span class="sh-val">seanseannery/opsfile</span> <span class="sh-val">https://github.com/seanseannery/opsfile</span>
+<span class="sh-cmd">brew</span> <span class="sh-env">install</span> <span class="sh-val">seanseannery/opsfile/opsfile</span></code></pre>
       </div>
 
       <div id="tab-npm" class="tab-content code-block">
-        <pre><code>npm install -g github:seanseannery/opsfile</code></pre>
+        <pre><code><span class="sh-cmd">npm</span> <span class="sh-env">install</span> <span class="sh-varname">-g</span> <span class="sh-val">github:seanseannery/opsfile</span></code></pre>
+      </div>
+
+      <div id="tab-claude" class="tab-content code-block">
+        <p class="prereq-note">Requires the <code>ops</code> CLI to be installed first — use curl, Homebrew, or npm above.</p>
+        <pre><code><span class="sh-cmd">/plugin</span> <span class="sh-env">marketplace add</span> <span class="sh-val">seanseannery/opsfile</span>
+<span class="sh-cmd">/plugin</span> <span class="sh-env">install</span> <span class="sh-val">ops@opsfile</span></code></pre>
       </div>
     </div>
   </section>
@@ -115,6 +130,13 @@ brew install seanseannery/opsfile/opsfile</code></pre>
         echo "Using AWS profile: <span class="sh-subst">$(AWS_PROFILE)</span>"</code></pre>
       </div>
 
+      <div class="or-divider"><span>or use the Claude plugin</span></div>
+
+      <p>Run <code class="skill-inline">/ops:init-opsfile</code> to have Claude analyze your repo's tech stack and generate a tailored Opsfile automatically.</p>
+      <div class="bash-example">
+        <span class="prompt">$</span> claude "<span class="skill">/ops:init-opsfile</span>"
+      </div>
+
       <h3>Step 2: Run ops commands</h3>
       <p>Run commands with the following syntax:</p>
       <div class="bash-example">
@@ -147,13 +169,35 @@ brew install seanseannery/opsfile/opsfile</code></pre>
         <div><span class="prompt">$</span> ops local logs</div>
         <div><span class="prompt">$</span> ops prod k8s -namespace myspace</div>
       </div>
+
+      <div class="or-divider"><span>or use the Claude plugin</span></div>
+
+      <p>Pass a command directly or describe what you need in plain English — <code class="skill-inline">/ops:run</code> discovers your available commands and resolves the best match.</p>
+      <div class="bash-example">
+        <div><span class="prompt">$</span> claude "<span class="skill">/ops:run</span> prod tail-logs"</div>
+        <div><span class="prompt">$</span> claude "<span class="skill">/ops:run</span> --list"</div>
+        <div><span class="prompt">$</span> claude "<span class="skill">/ops:run</span> are there any errors in staging?"</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CLAUDE PLUGIN -->
+  <section id="claude-plugin" class="install-section">
+    <div class="container">
+      <h2>Claude Code Plugin</h2>
+      <p>Install the <strong>ops</strong> plugin once to unlock the Claude skill alternatives shown above.</p>
+      <p class="prereq-note">Requires the <code>ops</code> CLI to be installed first — <a href="#install">install it above</a>.</p>
+      <div class="code-block">
+        <pre><code><span class="sh-cmd">/plugin</span> <span class="sh-env">marketplace add</span> <span class="sh-val">seanseannery/opsfile</span>
+<span class="sh-cmd">/plugin</span> <span class="sh-env">install</span> <span class="sh-val">ops@opsfile</span></code></pre>
+      </div>
     </div>
   </section>
 
   <!-- FEATURES -->
-  <section class="features-section">
+  <section class="features-section" id="features">
     <div class="container">
-      <h2>Why use it?</h2>
+      <h2 >Why use it?</h2>
       <div class="feature-grid">
         <div class="feature-card">
           <div class="feature-icon">⚡</div>
@@ -163,7 +207,7 @@ brew install seanseannery/opsfile/opsfile</code></pre>
         <div class="feature-card">
           <div class="feature-icon">🤖</div>
           <div class="feature-title">Less AI tokens</div>
-          <p>Let agents run ops scripts instead of googling commands</p>
+          <p>CLI > MCP. Agents run ops scripts instead of googling commands or loading large MCP context</p>
         </div>
         <div class="feature-card">
           <div class="feature-icon">📖</div>
@@ -243,7 +287,7 @@ brew install seanseannery/opsfile/opsfile</code></pre>
       btn.title = 'Copy';
       btn.setAttribute('aria-label', 'Copy');
       btn.addEventListener('click', () => {
-        const code = block.querySelector('code');
+        const code = block.querySelector('pre > code');
         navigator.clipboard.writeText(code.textContent.trim()).then(() => {
           btn.innerHTML = checkIcon;
           setTimeout(() => { btn.innerHTML = copyIcon; }, 2000);

--- a/docs/site/style.css
+++ b/docs/site/style.css
@@ -18,6 +18,11 @@
   --green:    #859900;
 }
 
+/* ─── Section Headers ────────────────────────────────────────── */
+section h2 {
+  text-align: center;
+}
+
 /* ─── Global ─────────────────────────────────────────────────── */
 * {
   box-sizing: border-box;
@@ -109,6 +114,7 @@ a:hover {
   font-size: 1.4rem;
   color: var(--emphasis);
   margin-bottom: 8px;
+  font-family: monospace;
 }
 
 .tagline code {
@@ -206,7 +212,7 @@ a:hover {
 .terminal-dot:nth-child(3) { background: var(--green); }
 
 .terminal-body {
-  padding: 20px;
+  padding: 20px 20px 48px;
   font-family: monospace;
   font-size: 0.9rem;
   line-height: 1.8;
@@ -222,10 +228,15 @@ a:hover {
 .line:nth-child(2) { animation: appear-2 20s ease infinite; }
 .line:nth-child(3) { animation: appear-3 20s ease infinite; }
 .line:nth-child(4) { animation: appear-4 20s ease infinite; }
+.line:nth-child(5) { animation: appear-5 20s ease infinite; }
+.line:nth-child(6) { animation: appear-6 20s ease infinite; }
 
 .prompt { color: var(--green); }
 .cmd    { color: var(--bright); }
 .out    { color: var(--muted); }
+.skill  { color: var(--orange); }
+
+.line:has(.prompt) { margin-top: 10px; }
 
 .cursor {
   display: inline-block;
@@ -257,6 +268,18 @@ a:hover {
 @keyframes appear-4 {
   0%,  17%  { opacity: 0; transform: translateY(4px); }
   19%, 88%  { opacity: 1; transform: none; }
+  96%, 100% { opacity: 0; transform: none; }
+}
+
+@keyframes appear-5 {
+  0%,  22%  { opacity: 0; transform: translateY(4px); }
+  24%, 88%  { opacity: 1; transform: none; }
+  96%, 100% { opacity: 0; transform: none; }
+}
+
+@keyframes appear-6 {
+  0%,  27%  { opacity: 0; transform: translateY(4px); }
+  29%, 88%  { opacity: 1; transform: none; }
   96%, 100% { opacity: 0; transform: none; }
 }
 
@@ -421,6 +444,50 @@ pre > code {
   font-family: monospace;
 }
 
+/* ─── Prereq Note ────────────────────────────────────────────── */
+.prereq-note {
+  font-size: 0.85rem;
+  color: var(--muted);
+  border-left: 3px solid var(--yellow);
+  padding-left: 10px;
+  margin: 12px 0;
+}
+
+.prereq-note code {
+  color: var(--emphasis);
+  font-family: monospace;
+}
+
+/* ─── OR Divider ─────────────────────────────────────────────── */
+.or-divider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 32px 0 20px;
+  color: var(--muted);
+  font-size: 0.85rem;
+  font-family: monospace;
+}
+
+.or-divider::before,
+.or-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--subtle);
+}
+
+.skill-inline {
+  color: var(--orange);
+  font-family: monospace;
+}
+
+/* ─── Claude Plugin Section ──────────────────────────────────── */
+#claude-plugin h4 code {
+  color: var(--orange);
+  font-family: monospace;
+}
+
 /* ─── Usage Section ──────────────────────────────────────────── */
 #usage,
 .usage-section {
@@ -429,11 +496,18 @@ pre > code {
 }
 
 .usage-section h2,
-.usage-section h3,
-#usage h2,
-#usage h3 {
+#usage h2 {
   color: var(--emphasis);
   font-family: monospace;
+}
+
+.usage-section h3,
+#usage h3 {
+  color: var(--bright);
+  font-family: monospace;
+  font-size: 1.3rem;
+  margin-top: 40px;
+  margin-bottom: 12px;
 }
 
 .opsfile-example {

--- a/skills/init-opsfile/SKILL.md
+++ b/skills/init-opsfile/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: init-opsfile
+description: Analyze the current repository's tech stack and generate a starter Opsfile with common local development and operations commands tailored to the detected platform.
+---
+
+Analyze the current repository and generate an `Opsfile` tailored to its tech stack and deployment platform. Customize specifically for this project's language, infrastructure, and environments. Always include a `local` environment at minimum. Never store passwords, tokens, or other secrets inline.
+
+**Before starting:** read the Opsfile syntax specification and platform templates from the reference file installed alongside this skill: `${CLAUDE_PLUGIN_ROOT}/skills/init-opsfile/reference.md`
+
+---
+
+## Steps
+
+### 1. Detect tech stack
+
+Scan the repository root, documentation, and config for these signals:
+
+**Documentation (read first for context):**
+- `README.md`, `AGENTS.md`, `CLAUDE.md`, `Makefile`
+
+**Language / Framework:**
+- `go.mod` → Go
+- `package.json` → Node.js (check `scripts` for framework hints)
+- `pom.xml` or `build.gradle` → Java / JVM
+- `requirements.txt`, `pyproject.toml`, or `setup.py` → Python
+- `Cargo.toml` → Rust
+- `Gemfile` → Ruby
+
+**Containerization:**
+- `Dockerfile` → Docker image build
+- `docker-compose.yml` or `docker-compose.yaml` → Docker Compose local dev
+
+**Deployment Platform (check in order of specificity):**
+- `.github/workflows/` referencing `aws`, `ecs`, or `ecr` → AWS ECS
+- `.github/workflows/` referencing `gke`, `cloud-run`, or `gcp` → GCP Cloud Run / GKE
+- `.github/workflows/` referencing `azure`, `aks`, or `acr` → Azure
+- `k8s/`, `kubernetes/`, `helm/` directories, or `kind: Deployment` in any YAML → Kubernetes
+- No cloud signals detected → bare-metal / local only
+
+**Infrastructure as Code (supplement or confirm platform detection):**
+- `terraform/` or `*.tf` files → scan for `provider` blocks (`aws`, `google`, `azurerm`) to confirm cloud platform; scan `variable` and `locals` blocks, workspace names, and directory structure (e.g. `envs/prod/`, `environments/staging/`) to infer environment names
+- `cloudformation/` or `*.yaml`/`*.json` containing `AWSTemplateFormatVersion` → AWS; scan `Parameters` and stack names for environment names
+- `cdk/` or files importing `aws-cdk-lib` / `@aws-cdk` → AWS; scan stack class names and context variables for environment names
+- `pulumi.yaml` or `Pulumi.*.yaml` → scan stack file names (e.g. `Pulumi.prod.yaml`, `Pulumi.staging.yaml`) for environment names and the `runtime` / provider config for platform
+- `ansible/` or `*.playbook.yml` with `hosts:` blocks → bare-metal / SSH; scan inventory files for host group names as environment names
+
+When IaC is found, use the detected environment names (e.g. `prod`, `staging`, `dev`) as the environment blocks in the generated Opsfile rather than generic placeholders.
+
+If multiple platforms are detected, combine the most relevant sections. Always include a `local` environment.
+
+### 2. Select and apply platform template
+
+From `reference.md`, choose the template matching the detected platform. Substitute real values found in the repo wherever possible. Mark anything unknown with a `# TODO:` comment.
+
+### 3. Generate the Opsfile
+
+Produce an `Opsfile` customized for this specific repo:
+
+- Substitute real detected values (cluster names, namespaces, log groups, service names) wherever possible
+- Mark unknown values with `# TODO:` comments
+- Include a `local` environment with at minimum: `tail-logs`, `check-resources`, `restart`
+- Include `default:` blocks wherever the command works across environments
+- Add a `#` comment above each command (shown as its description by `ops --list`)
+- Use `$(VAR)` for any secrets; add a comment directing the user to `.ops_secrets.env`
+
+### 4. Confirm and write
+
+- Summarize the detected tech stack and which platform template was used
+- Show the full generated Opsfile as a preview
+- Ask the user to confirm before writing
+- Write `Opsfile` to the repository root (or a location the user specifies)
+- Run `ops --list` after writing to confirm it parses correctly
+- Remind the user to add secret values to `.ops_secrets.env` and add that file to `.gitignore`

--- a/skills/init-opsfile/reference.md
+++ b/skills/init-opsfile/reference.md
@@ -1,0 +1,393 @@
+# Opsfile syntax reference
+
+An Opsfile is a plain-text file (no extension) placed at the repository root. It follows similar, but not exact syntax as Makefiles.
+
+## Variables
+
+```
+NAME=value                      # unscoped — available in all environments
+prod_NAME=value                 # env-scoped — only resolved when env is "prod"
+```
+
+Variable references use `$(NAME)` syntax. The resolver checks (in order):
+1. Opsfile env-scoped (`prod_NAME`)
+2. Shell env-scoped (`prod_NAME` from environment)
+3. Opsfile unscoped (`NAME`)
+4. Shell unscoped (`NAME` from environment)
+
+Non-identifier tokens like `$(shell date +%s)` pass through unchanged as subshell expressions.
+
+Secrets must never be defined inline. Use `$(SECRET_VAR)` and inject at runtime:
+- via `.ops_secrets.env` (auto-loaded if present next to the Opsfile)
+- via `ops -e .env.prod <env> <command>`
+
+## Commands
+
+```
+# Comment above a command becomes its description in `ops --list`
+command-name:
+    environment-name:
+        shell line one
+        shell line two \
+            continued
+    default:
+        fallback shell line
+```
+
+Rules:
+- Command names: non-indented, end with `:`
+- Environment blocks: one level of indentation, end with `:`
+- Shell lines: two levels of indentation
+- `default:` is used as a fallback when the requested environment has no block
+- Backslash `\` continues a shell line
+- `#` prefix: is a line-level comment for that line only
+- `@` prefix: suppress echo of the command (show output only)
+- `-` prefix: ignore non-zero exit codes and proceed executing
+- `-@` prefix: both
+
+## Full syntax example
+
+```
+# Unscoped variables
+APP_PORT=8080
+SERVICE_NAME=my-service
+
+# Env-scoped variables
+prod_HOST=prod.internal
+staging_HOST=staging.internal
+
+# Tail application logs
+tail-logs:
+    local:
+        docker compose logs app --follow --tail 100
+    default:
+        ssh $(SSH_USER)@$(HOST) "tail -f /var/log/$(SERVICE_NAME)/app.log"
+
+# Restart the service
+restart:
+    local:
+        docker compose restart app
+    default:
+        ssh $(SSH_USER)@$(HOST) "sudo systemctl restart $(SERVICE_NAME)"
+```
+
+---
+
+# Platform templates
+
+Use the matching template as a starting point. Substitute real values detected from the repo wherever possible; mark unknowns with `# TODO:` comments.
+
+## Docker Compose (local)
+
+```
+COMPOSE_FILE=docker-compose.yml
+APP_CONTAINER=app
+DB_CONTAINER=postgres
+APP_PORT=8080
+
+# Tail application logs
+tail-logs:
+    default:
+        docker compose -f $(COMPOSE_FILE) logs $(APP_CONTAINER) --follow --tail 100
+
+# Restart the app container
+restart:
+    default:
+        docker compose -f $(COMPOSE_FILE) restart $(APP_CONTAINER)
+    full:
+        docker compose -f $(COMPOSE_FILE) down && \
+        docker compose -f $(COMPOSE_FILE) up -d
+
+# Check health endpoint
+health-check:
+    default:
+        curl -sf http://localhost:$(APP_PORT)/health | jq .
+
+# Container resource usage
+check-resources:
+    default:
+        docker stats --no-stream $(APP_CONTAINER)
+
+# Check downstream dependency connectivity
+downstream-deps:
+    default:
+        docker exec $(DB_CONTAINER) pg_isready
+```
+
+## AWS ECS
+
+```
+prod_AWS_REGION=us-east-1          # TODO: set your regions
+staging_AWS_REGION=us-west-2
+
+prod_CLUSTER=my-service-prod       # TODO: set your cluster names
+staging_CLUSTER=my-service-staging
+
+prod_LOG_GROUP=/aws/ecs/my-service-prod    # TODO: set your log groups
+staging_LOG_GROUP=/aws/ecs/my-service-staging
+
+# Tail CloudWatch logs
+tail-logs:
+    default:
+        aws logs tail $(LOG_GROUP) \
+            --follow \
+            --since 15m \
+            --region $(AWS_REGION)
+
+# Running vs desired task count
+instance-count:
+    default:
+        aws ecs describe-services \
+            --cluster $(CLUSTER) \
+            --services my-service \
+            --region $(AWS_REGION) \
+            --query "services[0].{Running:runningCount,Desired:desiredCount,Pending:pendingCount}"
+
+# Active CloudWatch alarms
+check-alarms:
+    default:
+        aws cloudwatch describe-alarms \
+            --state-value ALARM \
+            --region $(AWS_REGION) \
+            --query "MetricAlarms[*].{Name:AlarmName,Reason:StateReason}" \
+            --output table
+
+# Count ERROR log events in last 30 minutes
+error-rate:
+    default:
+        aws logs filter-log-events \
+            --log-group-name $(LOG_GROUP) \
+            --start-time $(shell date -d '30 minutes ago' +%s000) \
+            --filter-pattern "ERROR" \
+            --region $(AWS_REGION) \
+            --query "length(events)" \
+            --output text
+
+# Force a new ECS deployment (rollback)
+rollback:
+    default:
+        aws ecs update-service \
+            --cluster $(CLUSTER) \
+            --service my-service \
+            --force-new-deployment \
+            --region $(AWS_REGION)
+```
+
+## Kubernetes
+
+```
+prod_NAMESPACE=my-service-prod     # TODO: set your namespaces
+staging_NAMESPACE=my-service-staging
+local_NAMESPACE=my-service-local
+
+prod_CONTEXT=my-prod-context       # TODO: set your kubectl contexts
+staging_CONTEXT=my-staging-context
+
+DEPLOYMENT=my-service
+CONTAINER=app
+
+# Pod status and count
+pod-count:
+    default:
+        kubectl get pods \
+            --namespace $(NAMESPACE) \
+            --context $(CONTEXT) \
+            --output wide
+    local:
+        kubectl get pods --namespace $(NAMESPACE)
+
+# CPU and memory usage per pod
+check-resources:
+    default:
+        kubectl top pods \
+            --namespace $(NAMESPACE) \
+            --context $(CONTEXT)
+    local:
+        kubectl top pods --namespace $(NAMESPACE)
+
+# Tail pod logs
+tail-logs:
+    default:
+        kubectl logs \
+            --namespace $(NAMESPACE) \
+            --context $(CONTEXT) \
+            --selector app=$(DEPLOYMENT) \
+            --container $(CONTAINER) \
+            --follow \
+            --tail 100
+    local:
+        kubectl logs \
+            --namespace $(NAMESPACE) \
+            --selector app=$(DEPLOYMENT) \
+            --follow \
+            --tail 100
+
+# Rollout restart
+restart:
+    default:
+        kubectl rollout restart deployment/$(DEPLOYMENT) \
+            --namespace $(NAMESPACE) \
+            --context $(CONTEXT)
+    local:
+        kubectl rollout restart deployment/$(DEPLOYMENT) --namespace $(NAMESPACE)
+
+# Roll back to previous revision
+rollback:
+    default:
+        kubectl rollout undo deployment/$(DEPLOYMENT) \
+            --namespace $(NAMESPACE) \
+            --context $(CONTEXT)
+
+# Deployment health
+health-check:
+    default:
+        kubectl get deployment $(DEPLOYMENT) \
+            --namespace $(NAMESPACE) \
+            --context $(CONTEXT) \
+            --output jsonpath='{.status.conditions[*].message}'
+```
+
+## GCP Cloud Run / GKE
+
+```
+prod_PROJECT=my-service-prod-123   # TODO: set your GCP project IDs
+staging_PROJECT=my-service-staging-456
+
+prod_REGION=us-central1            # TODO: set your regions
+staging_REGION=us-east1
+
+SERVICE=my-service
+LOG_FILTER=resource.type="cloud_run_revision" AND resource.labels.service_name="my-service"
+
+# Tail Cloud Logging
+tail-logs:
+    default:
+        gcloud logging read '$(LOG_FILTER)' \
+            --project=$(PROJECT) \
+            --limit=100 \
+            --format="value(timestamp,textPayload)" \
+            --freshness=15m
+
+# Cloud Run replica count
+instance-count:
+    default:
+        gcloud run services describe $(SERVICE) \
+            --project=$(PROJECT) \
+            --region=$(REGION) \
+            --format="value(status.observedGeneration,status.conditions[0].status)"
+
+# Error count in last 30 minutes
+error-rate:
+    default:
+        gcloud logging read '$(LOG_FILTER) AND severity>=ERROR' \
+            --project=$(PROJECT) \
+            --freshness=30m \
+            --format="value(timestamp,textPayload)" | wc -l
+
+# Roll back to previous revision
+rollback:
+    default:
+        gcloud run services update-traffic $(SERVICE) \
+            --project=$(PROJECT) \
+            --region=$(REGION) \
+            --to-revisions=$(shell gcloud run revisions list --service=$(SERVICE) --project=$(PROJECT) --region=$(REGION) --format="value(name)" --limit=2 | tail -1)=100
+```
+
+## Azure Container Apps / AKS
+
+```
+# AZURE_SUBSCRIPTION_ID is a secret — inject via env-file:
+#   ops -e .ops_secrets.env prod tail-logs
+# .ops_secrets.env:
+#   prod_AZURE_SUBSCRIPTION_ID=aaaa-bbbb-cccc
+#   staging_AZURE_SUBSCRIPTION_ID=dddd-eeee-ffff
+
+prod_RESOURCE_GROUP=my-service-prod-rg     # TODO: set your resource groups
+staging_RESOURCE_GROUP=my-service-staging-rg
+
+prod_APP_NAME=my-service-prod              # TODO: set your app names
+staging_APP_NAME=my-service-staging
+
+LOG_WORKSPACE=my-service-logs
+
+# Tail container logs via Log Analytics
+tail-logs:
+    default:
+        az monitor log-analytics query \
+            --workspace $(LOG_WORKSPACE) \
+            --analytics-query "ContainerLog | order by TimeGenerated desc | take 100" \
+            --subscription $(AZURE_SUBSCRIPTION_ID)
+
+# List running replicas
+instance-count:
+    default:
+        az containerapp replica list \
+            --name $(APP_NAME) \
+            --resource-group $(RESOURCE_GROUP) \
+            --subscription $(AZURE_SUBSCRIPTION_ID) \
+            --output table
+
+# Active metric alerts
+check-alarms:
+    default:
+        az monitor metrics alert list \
+            --resource-group $(RESOURCE_GROUP) \
+            --subscription $(AZURE_SUBSCRIPTION_ID) \
+            --output table
+
+# Error count from logs
+error-rate:
+    default:
+        az monitor log-analytics query \
+            --workspace $(LOG_WORKSPACE) \
+            --analytics-query "ContainerLog | where LogEntry contains 'ERROR' | where TimeGenerated > ago(30m) | summarize count()" \
+            --subscription $(AZURE_SUBSCRIPTION_ID) \
+            --output table
+```
+
+## Bare-metal / SSH
+
+```
+prod_HOST=prod-srv-01.internal     # TODO: set your hostnames
+staging_HOST=staging-srv-01.internal
+
+prod_SSH_USER=deploy
+staging_SSH_USER=deploy
+
+SERVICE_NAME=my-service
+LOG_FILE=/var/log/my-service/app.log
+
+# SSH_KEY is a secret — inject via env-file:
+#   ops -e .ops_secrets.env prod tail-logs
+# .ops_secrets.env:
+#   SSH_KEY=~/.ssh/prod_deploy_key
+
+# Tail application log file
+tail-logs:
+    default:
+        ssh $(SSH_USER)@$(HOST) "tail -f $(LOG_FILE)"
+    prod:
+        ssh -i $(SSH_KEY) $(SSH_USER)@$(HOST) "tail -f $(LOG_FILE)"
+
+# CPU, memory, and disk usage
+check-resources:
+    default:
+        ssh $(SSH_USER)@$(HOST) \
+            "echo '=== CPU ===' && top -bn1 | grep 'Cpu(s)' && \
+             echo '=== Memory ===' && free -h && \
+             echo '=== Disk ===' && df -h"
+
+# Restart the systemd service
+restart:
+    default:
+        ssh $(SSH_USER)@$(HOST) "sudo systemctl restart $(SERVICE_NAME)"
+    prod:
+        ssh -i $(SSH_KEY) $(SSH_USER)@$(HOST) \
+            "sudo systemctl restart $(SERVICE_NAME) && \
+             sudo systemctl status $(SERVICE_NAME)"
+
+# Service health via systemd
+health-check:
+    default:
+        ssh $(SSH_USER)@$(HOST) "sudo systemctl status $(SERVICE_NAME) --no-pager"
+```

--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: run
+description: Run an ops command from the current repo's Opsfile. Accepts direct CLI arguments (/ops:run prod tail-logs) or natural language (/ops:run tail the production logs and grep for errors).
+---
+
+Run ops commands from the current repo's Opsfile. Handle both direct CLI invocations and natural language requests.
+
+**Input:** `$ARGUMENTS`
+
+## Behavior
+
+### 1. Detect input type
+
+If `$ARGUMENTS` begins with a CLI flag (e.g. `--`, `-`) or matches the pattern of ops positional arguments (e.g. `<environment> <command>`, or a known flag like `--list`), treat it as **direct CLI arguments**.
+
+Otherwise, treat it as a **natural language request**.
+
+### 2. Direct CLI mode
+
+Run the command directly:
+
+```bash
+ops $ARGUMENTS
+```
+
+### 3. Natural language mode
+
+a. First, discover what commands are available:
+
+```bash
+ops --list
+```
+
+b. Read the output to understand the available commands, environments, and descriptions.
+
+c. Determine which command and environment best matches the user's intent. If the request is ambiguous or no command clearly matches, show the user the available options and ask them to clarify if they would like to choose a different ops command or attempt to generate a new (non-ops) cli command using a different tool that could fulfil their request.
+
+d. Tell the user the command you resolved before running it:
+
+```
+I'll run: ops <environment> <command>
+```
+
+e. Execute it:
+
+```bash
+ops <resolved-environment> <resolved-command> [resolved-args]
+```
+
+f. If the skill ends up running a custom command because there wasnt one defined in Opsfile.  Ask if they would like to add what was just run as a new Opsfile command.
+
+## Safety
+
+- You **must not** issue commands (ops or otherwise) that would delete, destroy, remove anything in 'prod' or 'production' or any customer facing environments without direct user confirmation
+- You **must** inform the user of any risk of outdated infrastructure-as-code when the user makes changes to infrastructure directly. Unless they dont utilize IaC for the project.
+- You **must not** store, share, or print any infrastructure secrets in memory that may be used to gain access to critical systems. Critical Secrets should stored either in environment variables or .ops_secrets.env or the autheticated sessions of the underlying bash tools.
+
+## Error handling
+
+- If `ops` is not installed, direct the user to install it: https://github.com/seanseannery/opsfile
+- If no Opsfile is found, explain that `ops` searches the current and parent directories for an `Opsfile`, and suggest `/ops:init-opsfile` to scaffold one for the current repo
+- If the requested command or environment does not exist in the Opsfile, show the available options from `ops --list` and ask the user to clarify.
+- If the ops command executes, but underlying bash commands fail to execute, suggest a potential solution for why the specific bash command failed. Investigate incorrectly set Opsfile variables.


### PR DESCRIPTION
## Key Changes

- Add `.claude-plugin/plugin.json` — plugin manifest (name: `ops`, skills path `./skills/`)
- Add `skills/run/SKILL.md` — `/ops:run` skill: accepts direct CLI args or natural language; runs `ops --list` to discover commands when given a prompt, shows resolved command before executing
- Add `skills/init-opsfile/SKILL.md` + `skills/init-opsfile/reference.md` — `/ops:init-opsfile` skill: detects tech stack (language, containerization, cloud platform, IaC), selects matching platform template, generates a tailored Opsfile; reference file is self-contained so users don't need the repo cloned
- Add `SessionStart` hook in `plugin.json` to warn if `ops` CLI is not installed
- Update `README.md` with Claude Code Plugin section (install + skill docs)
- Update `docs/site/index.html`: Claude Plugin nav entry, install tab, OR-dividers in Getting Started steps, Claude plugin section; bash syntax highlighting on all install tabs; terminal demo 3rd entry showing `claude "/ops:run ..."`; various style improvements (h3 prominence, tagline font, centered h2s, or-divider, prereq note)
- Update `docs/site/style.css`: new rules for `.skill`, `.skill-inline`, `.or-divider`, `.prereq-note`, section h2 centering, monospace tagline, h3 sizing, terminal padding and animation additions
- Update `AGENTS.md` directory structure

## Why do we need this?

Enables Claude Code users to install the `ops` plugin from this repo and use two skills: one to run ops commands by name or natural language (`/ops:run`), and one to scaffold a new Opsfile by analyzing the current repo's tech stack (`/ops:init-opsfile`). This makes `opsfile` accessible to AI-assisted workflows without requiring users to remember CLI syntax.

## New modules or other dependencies introduced

None — plugin is markdown + JSON only, no new Go code or external dependencies.

## How was this tested?

- All existing Go tests pass (pre-push hook verified)
- GitHub Pages site previewed locally via `python3 -m http.server`
- Plugin manifest, skill files, and reference file reviewed for correctness