### PR TITLE
refactor(internal): improve encapsulation, separation of concerns, and test coverage

### DIFF
--- a/cmd/ops/lister.go
+++ b/cmd/ops/lister.go
@@ -1,14 +1,16 @@
-package internal
+package main
 
 import (
 	"fmt"
 	"io"
 	"strings"
+
+	"sean_seannery/opsfile/internal"
 )
 
-// FormatCommandList writes a formatted summary of the Opsfile's commands and
+// formatCommandList writes a formatted summary of the Opsfile's commands and
 // environments to w. Commands are printed in cmdOrder; environments in envOrder.
-func FormatCommandList(w io.Writer, opsfilePath string, cmds map[string]OpsCommand, cmdOrder []string, envOrder []string) {
+func formatCommandList(w io.Writer, opsfilePath string, cmds map[string]internal.OpsCommand, cmdOrder []string, envOrder []string) {
 	fmt.Fprintf(w, "Commands Found in [%s]:\n", opsfilePath)
 	fmt.Fprintln(w)
 

--- a/cmd/ops/lister_test.go
+++ b/cmd/ops/lister_test.go
@@ -1,17 +1,18 @@
-package internal
+package main
 
 import (
 	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"sean_seannery/opsfile/internal"
 )
 
 func TestFormatCommandList(t *testing.T) {
 	cases := []struct {
 		name     string
 		path     string
-		cmds     map[string]OpsCommand
+		cmds     map[string]internal.OpsCommand
 		cmdOrder []string
 		envOrder []string
 		want     string
@@ -19,10 +20,10 @@ func TestFormatCommandList(t *testing.T) {
 		{
 			name: "commands with descriptions",
 			path: "./Opsfile",
-			cmds: map[string]OpsCommand{
-				"tail-logs":         {Name: "tail-logs", Description: "Tail CloudWatch logs", Environments: map[string][]string{"prod": {}}},
-				"show-profile":      {Name: "show-profile", Description: "Using AWS profile", Environments: map[string][]string{"default": {}}},
-				"list-instance-ips": {Name: "list-instance-ips", Description: "List the private IPs of running instances", Environments: map[string][]string{"prod": {}}},
+			cmds: map[string]internal.OpsCommand{
+				"tail-logs":         {Name: "tail-logs", Description: "Tail CloudWatch logs", Environments: map[string][]internal.ShellLine{"prod": {}}},
+				"show-profile":      {Name: "show-profile", Description: "Using AWS profile", Environments: map[string][]internal.ShellLine{"default": {}}},
+				"list-instance-ips": {Name: "list-instance-ips", Description: "List the private IPs of running instances", Environments: map[string][]internal.ShellLine{"prod": {}}},
 			},
 			cmdOrder: []string{"show-profile", "tail-logs", "list-instance-ips"},
 			envOrder: []string{"default", "local", "preprod", "prod"},
@@ -39,9 +40,9 @@ func TestFormatCommandList(t *testing.T) {
 		{
 			name: "commands without descriptions",
 			path: "./Opsfile",
-			cmds: map[string]OpsCommand{
-				"deploy":  {Name: "deploy", Environments: map[string][]string{"prod": {}}},
-				"restart": {Name: "restart", Environments: map[string][]string{"prod": {}}},
+			cmds: map[string]internal.OpsCommand{
+				"deploy":  {Name: "deploy", Environments: map[string][]internal.ShellLine{"prod": {}}},
+				"restart": {Name: "restart", Environments: map[string][]internal.ShellLine{"prod": {}}},
 			},
 			cmdOrder: []string{"deploy", "restart"},
 			envOrder: []string{"prod"},
@@ -57,10 +58,10 @@ func TestFormatCommandList(t *testing.T) {
 		{
 			name: "mixed descriptions and no descriptions",
 			path: "examples/Opsfile",
-			cmds: map[string]OpsCommand{
-				"build":  {Name: "build", Description: "Build the project", Environments: map[string][]string{"default": {}}},
-				"deploy": {Name: "deploy", Environments: map[string][]string{"prod": {}}},
-				"test":   {Name: "test", Description: "Run tests", Environments: map[string][]string{"default": {}}},
+			cmds: map[string]internal.OpsCommand{
+				"build":  {Name: "build", Description: "Build the project", Environments: map[string][]internal.ShellLine{"default": {}}},
+				"deploy": {Name: "deploy", Environments: map[string][]internal.ShellLine{"prod": {}}},
+				"test":   {Name: "test", Description: "Run tests", Environments: map[string][]internal.ShellLine{"default": {}}},
 			},
 			cmdOrder: []string{"build", "deploy", "test"},
 			envOrder: []string{"default", "prod"},
@@ -77,8 +78,8 @@ func TestFormatCommandList(t *testing.T) {
 		{
 			name: "environment order preserved",
 			path: "./Opsfile",
-			cmds: map[string]OpsCommand{
-				"cmd": {Name: "cmd", Environments: map[string][]string{"zebra": {}, "alpha": {}}},
+			cmds: map[string]internal.OpsCommand{
+				"cmd": {Name: "cmd", Environments: map[string][]internal.ShellLine{"zebra": {}, "alpha": {}}},
 			},
 			cmdOrder: []string{"cmd"},
 			envOrder: []string{"zebra", "alpha"},
@@ -93,10 +94,10 @@ func TestFormatCommandList(t *testing.T) {
 		{
 			name: "column alignment with varying name lengths",
 			path: "./Opsfile",
-			cmds: map[string]OpsCommand{
-				"a":              {Name: "a", Description: "short name", Environments: map[string][]string{"default": {}}},
-				"very-long-name": {Name: "very-long-name", Description: "long name", Environments: map[string][]string{"default": {}}},
-				"mid":            {Name: "mid", Description: "medium", Environments: map[string][]string{"default": {}}},
+			cmds: map[string]internal.OpsCommand{
+				"a":              {Name: "a", Description: "short name", Environments: map[string][]internal.ShellLine{"default": {}}},
+				"very-long-name": {Name: "very-long-name", Description: "long name", Environments: map[string][]internal.ShellLine{"default": {}}},
+				"mid":            {Name: "mid", Description: "medium", Environments: map[string][]internal.ShellLine{"default": {}}},
 			},
 			cmdOrder: []string{"a", "very-long-name", "mid"},
 			envOrder: []string{"default"},
@@ -113,7 +114,7 @@ func TestFormatCommandList(t *testing.T) {
 		{
 			name:     "single command",
 			path:     "./Opsfile",
-			cmds:     map[string]OpsCommand{"solo": {Name: "solo", Description: "Only command", Environments: map[string][]string{"prod": {}}}},
+			cmds:     map[string]internal.OpsCommand{"solo": {Name: "solo", Description: "Only command", Environments: map[string][]internal.ShellLine{"prod": {}}}},
 			cmdOrder: []string{"solo"},
 			envOrder: []string{"prod"},
 			want: "Commands Found in [./Opsfile]:\n" +
@@ -127,9 +128,25 @@ func TestFormatCommandList(t *testing.T) {
 		{
 			name:     "empty command map",
 			path:     "./Opsfile",
-			cmds:     map[string]OpsCommand{},
+			cmds:     map[string]internal.OpsCommand{},
 			cmdOrder: []string{},
 			envOrder: []string{},
+			// Environments line renders as "  \n" (two leading spaces, empty
+			// join result) — this is the intentional output for an empty env list.
+			want: "Commands Found in [./Opsfile]:\n" +
+				"\n" +
+				"Environments:\n" +
+				"  \n" +
+				"\n" +
+				"Commands:\n",
+		},
+		{
+			name:     "nil slices behave identically to empty slices",
+			path:     "./Opsfile",
+			cmds:     map[string]internal.OpsCommand{},
+			cmdOrder: nil,
+			envOrder: nil,
+			// Go: strings.Join(nil, sep) == "" and range over nil slice is a no-op.
 			want: "Commands Found in [./Opsfile]:\n" +
 				"\n" +
 				"Environments:\n" +
@@ -142,7 +159,7 @@ func TestFormatCommandList(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			FormatCommandList(&buf, tc.path, tc.cmds, tc.cmdOrder, tc.envOrder)
+			formatCommandList(&buf, tc.path, tc.cmds, tc.cmdOrder, tc.envOrder)
 			assert.Equal(t, tc.want, buf.String())
 		})
 	}

--- a/cmd/ops/main.go
+++ b/cmd/ops/main.go
@@ -22,9 +22,9 @@ func main() {
 		// Best-effort: show available commands alongside help
 		if dir, dirErr := resolveOpsfileDir(flags.Directory); dirErr == nil {
 			opsfilePath := filepath.Join(dir, opsFileName)
-			if _, cmds, cmdOrder, envOrder, perr := internal.ParseOpsFile(opsfilePath); perr == nil {
+			if parsed, perr := internal.ParseOpsFile(opsfilePath); perr == nil {
 				fmt.Fprintln(os.Stderr)
-				internal.FormatCommandList(os.Stderr, opsfilePath, cmds, cmdOrder, envOrder)
+				formatCommandList(os.Stderr, opsfilePath, parsed.Commands, parsed.CommandOrder, parsed.EnvOrder)
 			}
 		}
 		os.Exit(0)
@@ -50,7 +50,7 @@ func main() {
 		}
 	}
 
-	vars, commands, cmdOrder, envOrder, err := internal.ParseOpsFile(filepath.Join(dir, opsFileName))
+	parsed, err := internal.ParseOpsFile(filepath.Join(dir, opsFileName))
 	if err != nil {
 		slog.Error("parsing Opsfile: " + err.Error())
 		os.Exit(1)
@@ -70,7 +70,7 @@ func main() {
 				displayPath = rel
 			}
 		}
-		internal.FormatCommandList(os.Stdout, displayPath, commands, cmdOrder, envOrder)
+		formatCommandList(os.Stdout, displayPath, parsed.Commands, parsed.CommandOrder, parsed.EnvOrder)
 		os.Exit(0)
 	}
 
@@ -80,27 +80,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	resolved, err := internal.Resolve(args.OpsCommand, args.OpsEnv, commands, vars, envFileVars)
+	resolved, err := internal.Resolve(args.OpsCommand, args.OpsEnv, parsed.Commands, parsed.Variables, envFileVars, os.LookupEnv)
 	if err != nil {
 		slog.Error("resolving command: " + err.Error())
 		os.Exit(1)
 	}
 
-	if flags.DryRun {
-		if !flags.Silent {
-			for _, line := range resolved.Lines {
-				fmt.Println(line.Text)
-			}
-		}
-		return
-	}
-
-	shell := os.Getenv("SHELL")
-	if shell == "" {
-		shell = "/bin/sh"
-	}
-
-	if err := internal.Execute(resolved.Lines, shell, flags.Silent, os.Stderr); err != nil {
+	if err := internal.Execute(resolved.Lines, internal.DefaultShell(), flags.Silent, flags.DryRun, args.CommandArgs, os.Stderr); err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
 			os.Exit(exitErr.ExitCode())

--- a/examples/Opsfile_maclocal
+++ b/examples/Opsfile_maclocal
@@ -1,0 +1,77 @@
+APP_NAME=my-service
+APP_PORT=8080
+LOG_FILE=./logs/app.log
+
+# PID_FILE is optional — set if your app writes a pidfile:
+#   PID_FILE=./tmp/app.pid
+
+# CPU, memory, and disk usage snapshot
+check-resources:
+    default:
+        @echo "=== CPU ===" && \
+            top -l 1 -n 0 | grep -E "^CPU" && \
+        @echo "=== Memory ===" && \
+            vm_stat | grep -E "Pages (free|active|wired)" && \
+        @echo "=== Disk ===" && \
+            df -h | grep -E "^/dev|Filesystem"
+
+# Tail the local application log file
+tail-logs:
+    default:
+        tail -f $(LOG_FILE)
+
+# Show all processes for this service
+ps-app:
+    default:
+        ps aux | grep -i $(APP_NAME) | grep -v grep
+
+# List processes listening on all ports, or a specific port
+list-ports:
+    default:
+        lsof -i -P -n | grep LISTEN
+    app:
+        lsof -i :$(APP_PORT) -P -n
+
+# Kill whatever is holding the app port
+kill-port:
+    default:
+        lsof -ti :$(APP_PORT) | xargs kill -9 && \
+            echo "Killed process on port $(APP_PORT)"
+
+# Check if the local app health endpoint is responding
+health-check:
+    default:
+        curl -sf http://localhost:$(APP_PORT)/health | python3 -m json.tool
+
+# List Homebrew-managed background services and their status
+brew-services:
+    default:
+        brew services list
+
+# Flush macOS DNS cache
+flush-dns:
+    default:
+        sudo dscacheutil -flushcache && \
+            sudo killall -HUP mDNSResponder && \
+            echo "DNS cache flushed"
+
+# Basic network connectivity check
+network-check:
+    default:
+        echo "=== Default Route ===" && \
+            netstat -rn | grep default && \
+        echo "=== DNS ===" && \
+            scutil --dns | grep nameserver | head -3 && \
+        echo "=== Internet ===" && \
+            ping -c 3 1.1.1.1
+
+# Show open file descriptors and socket counts for the app process
+open-files:
+    default:
+        lsof -c $(APP_NAME) | wc -l | xargs echo "open file descriptors:" && \
+            lsof -c $(APP_NAME) -i | wc -l | xargs echo "open sockets:"
+
+# Open the macOS system log in Console.app
+open-console:
+    default:
+        open -a Console

--- a/internal/command_resolver.go
+++ b/internal/command_resolver.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"fmt"
-	"os"
 	"strings"
 )
 
@@ -34,16 +33,19 @@ type ResolvedCommand struct {
 // Variable substitution: $(VAR_NAME) tokens whose content is a bare identifier
 // are resolved against vars and envFileVars using a six-level priority chain
 // (shell wins — matches Docker Compose / Terraform convention):
-//  1. Shell env-scoped:    os.LookupEnv("env_VAR")
+//  1. Shell env-scoped:    envLookup("env_VAR")
 //  2. Opsfile env-scoped:  vars["env_VAR"]
 //  3. Env-file env-scoped: envFileVars["env_VAR"]
-//  4. Shell unscoped:      os.LookupEnv("VAR")
+//  4. Shell unscoped:      envLookup("VAR")
 //  5. Opsfile unscoped:    vars["VAR"]
 //  6. Env-file unscoped:   envFileVars["VAR"]
 //
 // $(…) tokens containing spaces or other non-identifier characters are passed
 // through unchanged, preserving shell subcommand syntax.
-func Resolve(commandName, env string, commands map[string]OpsCommand, vars, envFileVars OpsVariables) (ResolvedCommand, error) {
+//
+// envLookup is called to resolve shell environment variables. Pass os.LookupEnv
+// for production use, or a custom function for testing.
+func Resolve(commandName, env string, commands map[string]OpsCommand, vars, envFileVars OpsVariables, envLookup func(string) (string, bool)) (ResolvedCommand, error) {
 	cmd, ok := commands[commandName]
 	if !ok {
 		return ResolvedCommand{}, fmt.Errorf("command %q not found", commandName)
@@ -55,37 +57,18 @@ func Resolve(commandName, env string, commands map[string]OpsCommand, vars, envF
 	}
 
 	lines := make([]ResolvedLine, 0, len(raw))
-	for _, line := range raw {
-		silent := false
-		ignoreError := false
-		for len(line) > 0 {
-			switch line[0] {
-			case '@':
-				if !silent {
-					silent = true
-					line = line[1:]
-					continue
-				}
-			case '-':
-				if !ignoreError {
-					ignoreError = true
-					line = line[1:]
-					continue
-				}
-			}
-			break
-		}
-		substituted, err := substituteVars(line, env, vars, envFileVars)
+	for _, sl := range raw {
+		substituted, err := substituteVars(sl.Text, env, vars, envFileVars, envLookup)
 		if err != nil {
 			return ResolvedCommand{}, err
 		}
-		lines = append(lines, ResolvedLine{Text: substituted, Silent: silent, IgnoreError: ignoreError})
+		lines = append(lines, ResolvedLine{Text: substituted, Silent: sl.Silent, IgnoreError: sl.IgnoreError})
 	}
 	return ResolvedCommand{Lines: lines}, nil
 }
 
 // selectLines returns the shell lines for env, falling back to "default".
-func selectLines(cmd OpsCommand, env string) ([]string, error) {
+func selectLines(cmd OpsCommand, env string) ([]ShellLine, error) {
 	if lines, ok := cmd.Environments[env]; ok {
 		return lines, nil
 	}
@@ -98,7 +81,7 @@ func selectLines(cmd OpsCommand, env string) ([]string, error) {
 // substituteVars replaces $(VAR_NAME) references in a single shell line.
 // Only tokens whose content passes isIdentifier are treated as Opsfile
 // variable references; all others are left unchanged.
-func substituteVars(line, env string, vars, envFileVars OpsVariables) (string, error) {
+func substituteVars(line, env string, vars, envFileVars OpsVariables, envLookup func(string) (string, bool)) (string, error) {
 	var b strings.Builder
 	remaining := line
 	for {
@@ -120,7 +103,7 @@ func substituteVars(line, env string, vars, envFileVars OpsVariables) (string, e
 		remaining = remaining[end+1:]
 
 		if isIdentifier(token) {
-			val, err := resolveVar(token, env, vars, envFileVars)
+			val, err := resolveVar(token, env, vars, envFileVars, envLookup)
 			if err != nil {
 				return "", err
 			}
@@ -136,17 +119,17 @@ func substituteVars(line, env string, vars, envFileVars OpsVariables) (string, e
 }
 
 // resolveVar looks up varName using a six-level priority chain (shell wins):
-//  1. Shell env-scoped    (os.LookupEnv("env_VAR"))
+//  1. Shell env-scoped    (envLookup("env_VAR"))
 //  2. Opsfile env-scoped  (vars["env_VAR"])
 //  3. Env-file env-scoped (envFileVars["env_VAR"])
-//  4. Shell unscoped      (os.LookupEnv("VAR"))
+//  4. Shell unscoped      (envLookup("VAR"))
 //  5. Opsfile unscoped    (vars["VAR"])
 //  6. Env-file unscoped   (envFileVars["VAR"])
-func resolveVar(varName, env string, vars, envFileVars OpsVariables) (string, error) {
+func resolveVar(varName, env string, vars, envFileVars OpsVariables, envLookup func(string) (string, bool)) (string, error) {
 	scopedName := env + "_" + varName
 
 	// Priority 1: shell env-scoped
-	if val, ok := os.LookupEnv(scopedName); ok {
+	if val, ok := envLookup(scopedName); ok {
 		return val, nil
 	}
 	// Priority 2: Opsfile env-scoped
@@ -158,7 +141,7 @@ func resolveVar(varName, env string, vars, envFileVars OpsVariables) (string, er
 		return val, nil
 	}
 	// Priority 4: shell unscoped
-	if val, ok := os.LookupEnv(varName); ok {
+	if val, ok := envLookup(varName); ok {
 		return val, nil
 	}
 	// Priority 5: Opsfile unscoped

--- a/internal/command_resolver_test.go
+++ b/internal/command_resolver_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,9 +12,9 @@ import (
 // returns the variables and commands maps. Fails the test on parse error.
 func parseFixture(t *testing.T, content string) (OpsVariables, map[string]OpsCommand) {
 	t.Helper()
-	vars, commands, _, _, err := ParseOpsFile(writeTempOpsfile(t, content))
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
 	require.NoError(t, err, "ParseOpsFile")
-	return vars, commands
+	return parsed.Variables, parsed.Commands
 }
 
 // lineTexts extracts the Text field from each ResolvedLine for easy comparison.
@@ -34,7 +35,7 @@ list-instance-ips:
     preprod:
         aws ecs --list-instances
 `)
-	got, err := Resolve("list-instance-ips", "prod", commands, vars, nil)
+	got, err := Resolve("list-instance-ips", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	want := []string{`aws ec2 --list-instances`, `echo "done"`}
 	assert.Equal(t, want, lineTexts(got))
@@ -43,19 +44,33 @@ list-instance-ips:
 func TestResolve_EmptyCommandsMap(t *testing.T) {
 	commands := map[string]OpsCommand{}
 	vars := OpsVariables{}
-	_, err := Resolve("anything", "prod", commands, vars, nil)
+	_, err := Resolve("anything", "prod", commands, vars, nil, os.LookupEnv)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "not found")
 }
 
 func TestResolve_CommandWithEmptyShellLines(t *testing.T) {
 	commands := map[string]OpsCommand{
-		"empty": {Name: "empty", Environments: map[string][]string{"prod": {}}},
+		"empty": {Name: "empty", Environments: map[string][]ShellLine{"prod": {}}},
 	}
 	vars := OpsVariables{}
-	got, err := Resolve("empty", "prod", commands, vars, nil)
+	got, err := Resolve("empty", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Empty(t, got.Lines)
+}
+
+func TestResolve_NilEnvFileVarsIsSafe(t *testing.T) {
+	// nil envFileVars (no --env-file supplied) must not panic — nil map reads
+	// return the zero value in Go, so this is safe by language spec, but we
+	// test it explicitly to document and guard the assumption.
+	vars, commands := parseFixture(t, `
+deploy:
+    default:
+        echo hello
+`)
+	got, err := Resolve("deploy", "default", commands, vars, nil, os.LookupEnv)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"echo hello"}, lineTexts(got))
 }
 
 func TestResolve_MultipleVariablesInOneLine(t *testing.T) {
@@ -67,7 +82,7 @@ my-cmd:
     default:
         echo $(A) $(B)
 `)
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Equal(t, "echo hello world", got.Lines[0].Text)
 }
@@ -80,19 +95,19 @@ my-cmd:
     default:
         echo $(A) and $(A)
 `)
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Equal(t, "echo val and val", got.Lines[0].Text)
 }
 
 func TestResolve_UnclosedDollarParen(t *testing.T) {
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"echo $(incomplete"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo $(incomplete"}},
 		}},
 	}
 	vars := OpsVariables{}
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Equal(t, "echo $(incomplete", got.Lines[0].Text)
 }
@@ -105,7 +120,7 @@ my-cmd:
     default:
         $(VAR) $(shell cmd)
 `)
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Equal(t, "hello $(shell cmd)", got.Lines[0].Text)
 }
@@ -119,7 +134,7 @@ my-cmd:
     default:
         echo $(ACCOUNT)
 `)
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Equal(t, "echo prod-acct", got.Lines[0].Text)
 }
@@ -132,72 +147,72 @@ my-cmd:
     default:
         $(VAR) $(VAR)
 `)
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Equal(t, "x x", got.Lines[0].Text)
 }
 
 func TestResolve_UnclosedDollarParenAtEnd(t *testing.T) {
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"echo $("},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo $("}},
 		}},
 	}
 	vars := OpsVariables{}
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Equal(t, "echo $(", got.Lines[0].Text)
 }
 
 func TestResolve_EmptyToken(t *testing.T) {
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"echo $()"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo $()"}},
 		}},
 	}
 	vars := OpsVariables{}
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Equal(t, "echo $()", got.Lines[0].Text)
 }
 
 func TestResolve_ScopedLookupPriority(t *testing.T) {
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"echo $(HOST)"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo $(HOST)"}},
 		}},
 	}
 	vars := OpsVariables{
 		"prod_HOST": "prod.example.com",
 		"HOST":      "default.example.com",
 	}
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Equal(t, "echo prod.example.com", got.Lines[0].Text)
 }
 
 func TestResolve_UnscopedFallbackDirect(t *testing.T) {
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"echo $(HOST)"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo $(HOST)"}},
 		}},
 	}
 	vars := OpsVariables{
 		"HOST": "default.example.com",
 	}
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Equal(t, "echo default.example.com", got.Lines[0].Text)
 }
 
 func TestResolve_MissingVariableReturnsError(t *testing.T) {
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"echo $(NOPE)"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo $(NOPE)"}},
 		}},
 	}
 	vars := OpsVariables{}
-	_, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	_, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "not defined")
 }
@@ -210,7 +225,7 @@ tail-logs:
     default:
         aws cloudwatch logs --tail $(AWS_ACCOUNT)
 `)
-	got, err := Resolve("tail-logs", "prod", commands, vars, nil)
+	got, err := Resolve("tail-logs", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "aws cloudwatch logs --tail 1234567", got.Lines[0].Text)
@@ -224,7 +239,7 @@ tail-logs:
     local:
         docker logs myapp --follow
 `)
-	got, err := Resolve("tail-logs", "local", commands, vars, nil)
+	got, err := Resolve("tail-logs", "local", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "docker logs myapp --follow", got.Lines[0].Text)
@@ -239,7 +254,7 @@ tail-logs:
     default:
         echo $(AWS_ACCOUNT)
 `)
-	got, err := Resolve("tail-logs", "prod", commands, vars, nil)
+	got, err := Resolve("tail-logs", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Equal(t, "echo scoped", got.Lines[0].Text)
 }
@@ -252,7 +267,7 @@ tail-logs:
     default:
         echo $(AWS_ACCOUNT)
 `)
-	got, err := Resolve("tail-logs", "prod", commands, vars, nil)
+	got, err := Resolve("tail-logs", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Equal(t, "echo unscoped", got.Lines[0].Text)
 }
@@ -263,7 +278,7 @@ my-cmd:
     prod:
         echo hello
 `)
-	_, err := Resolve("nonexistent", "prod", commands, vars, nil)
+	_, err := Resolve("nonexistent", "prod", commands, vars, nil, os.LookupEnv)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "not found")
 }
@@ -274,7 +289,7 @@ my-cmd:
     prod:
         echo hello
 `)
-	_, err := Resolve("my-cmd", "staging", commands, vars, nil)
+	_, err := Resolve("my-cmd", "staging", commands, vars, nil, os.LookupEnv)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "no default")
 }
@@ -285,7 +300,7 @@ my-cmd:
     prod:
         echo $(MISSING_VAR)
 `)
-	_, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	_, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "not defined")
 }
@@ -296,7 +311,7 @@ my-cmd:
     prod:
         echo $(aws ec2 describe-instances)
 `)
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Equal(t, "echo $(aws ec2 describe-instances)", got.Lines[0].Text)
 }
@@ -311,7 +326,7 @@ deploy:
         aws ecs describe-clusters --cluster $(CLUSTER) --region $(REGION)
         echo "done in $(REGION)"
 `)
-	got, err := Resolve("deploy", "prod", commands, vars, nil)
+	got, err := Resolve("deploy", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	want := []string{
 		"aws ecs describe-clusters --cluster my-cluster --region us-east-1",
@@ -325,11 +340,11 @@ deploy:
 func TestResolveVar_UnscopedShellEnvFallback(t *testing.T) {
 	t.Setenv("VAR", "from-shell")
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"echo $(VAR)"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo $(VAR)"}},
 		}},
 	}
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Equal(t, "echo from-shell", got.Lines[0].Text)
 }
@@ -337,11 +352,11 @@ func TestResolveVar_UnscopedShellEnvFallback(t *testing.T) {
 func TestResolveVar_EnvScopedShellEnv(t *testing.T) {
 	t.Setenv("prod_VAR", "shell-scoped")
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"echo $(VAR)"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo $(VAR)"}},
 		}},
 	}
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Equal(t, "echo shell-scoped", got.Lines[0].Text)
 }
@@ -349,12 +364,12 @@ func TestResolveVar_EnvScopedShellEnv(t *testing.T) {
 func TestResolveVar_ShellEnvScopedBeatsOpsfileEnvScoped(t *testing.T) {
 	t.Setenv("prod_VAR", "shell-scoped")
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"echo $(VAR)"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo $(VAR)"}},
 		}},
 	}
 	vars := OpsVariables{"prod_VAR": "opsfile-scoped"}
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Equal(t, "echo shell-scoped", got.Lines[0].Text)
 }
@@ -362,12 +377,12 @@ func TestResolveVar_ShellEnvScopedBeatsOpsfileEnvScoped(t *testing.T) {
 func TestResolveVar_ShellEnvScopedBeatsOpsfileUnscoped(t *testing.T) {
 	t.Setenv("prod_VAR", "shell-scoped")
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"echo $(VAR)"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo $(VAR)"}},
 		}},
 	}
 	vars := OpsVariables{"VAR": "opsfile-unscoped"}
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Equal(t, "echo shell-scoped", got.Lines[0].Text)
 }
@@ -375,12 +390,12 @@ func TestResolveVar_ShellEnvScopedBeatsOpsfileUnscoped(t *testing.T) {
 func TestResolveVar_ShellUnscopedBeatsOpsfileUnscoped(t *testing.T) {
 	t.Setenv("VAR", "shell-unscoped")
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"echo $(VAR)"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo $(VAR)"}},
 		}},
 	}
 	vars := OpsVariables{"VAR": "opsfile-unscoped"}
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Equal(t, "echo shell-unscoped", got.Lines[0].Text)
 }
@@ -388,11 +403,11 @@ func TestResolveVar_ShellUnscopedBeatsOpsfileUnscoped(t *testing.T) {
 func TestResolveVar_ShellUnscopedIsPriority4(t *testing.T) {
 	t.Setenv("VAR", "shell-unscoped")
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"echo $(VAR)"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo $(VAR)"}},
 		}},
 	}
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Equal(t, "echo shell-unscoped", got.Lines[0].Text)
 }
@@ -454,11 +469,11 @@ func TestResolveVar_PriorityChain(t *testing.T) {
 				t.Setenv(k, v)
 			}
 			commands := map[string]OpsCommand{
-				"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-					"prod": {"echo $(VAR)"},
+				"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+					"prod": {{Text: "echo $(VAR)"}},
 				}},
 			}
-			got, err := Resolve("my-cmd", "prod", commands, tc.opsfileVars, tc.envFileVars)
+			got, err := Resolve("my-cmd", "prod", commands, tc.opsfileVars, tc.envFileVars, os.LookupEnv)
 			require.NoError(t, err)
 			assert.Equal(t, "echo "+tc.want, got.Lines[0].Text)
 		})
@@ -469,11 +484,11 @@ func TestResolveVar_MixedSources(t *testing.T) {
 	t.Setenv("B", "from-shell")
 	vars := OpsVariables{"A": "from-opsfile"}
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"echo $(A) $(B)"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo $(A) $(B)"}},
 		}},
 	}
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Equal(t, "echo from-opsfile from-shell", got.Lines[0].Text)
 }
@@ -481,11 +496,11 @@ func TestResolveVar_MixedSources(t *testing.T) {
 func TestResolveVar_EmptyShellEnvValue(t *testing.T) {
 	t.Setenv("VAR", "")
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"echo $(VAR)"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo $(VAR)"}},
 		}},
 	}
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Equal(t, "echo ", got.Lines[0].Text)
 }
@@ -493,22 +508,22 @@ func TestResolveVar_EmptyShellEnvValue(t *testing.T) {
 func TestResolveVar_NonIdentifierUnaffectedByShellEnv(t *testing.T) {
 	t.Setenv("aws", "should-not-matter")
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"echo $(aws ec2 describe-instances)"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo $(aws ec2 describe-instances)"}},
 		}},
 	}
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Equal(t, "echo $(aws ec2 describe-instances)", got.Lines[0].Text)
 }
 
 func TestResolveVar_AbsentFromAllSources(t *testing.T) {
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"echo $(DEFINITELY_NOT_SET_XYZ123)"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo $(DEFINITELY_NOT_SET_XYZ123)"}},
 		}},
 	}
-	_, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	_, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "not defined")
 }
@@ -516,13 +531,13 @@ func TestResolveVar_AbsentFromAllSources(t *testing.T) {
 func TestResolveVar_EnvFileScopedBeatsOpsfileUnscoped(t *testing.T) {
 	// P3 (env-file env-scoped) must beat P5 (Opsfile unscoped).
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"echo $(VAR)"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo $(VAR)"}},
 		}},
 	}
 	vars := OpsVariables{"VAR": "opsfile-unscoped"}           // P5
 	envFileVars := OpsVariables{"prod_VAR": "envfile-scoped"} // P3
-	got, err := Resolve("my-cmd", "prod", commands, vars, envFileVars)
+	got, err := Resolve("my-cmd", "prod", commands, vars, envFileVars, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Equal(t, "echo envfile-scoped", got.Lines[0].Text)
 }
@@ -530,51 +545,56 @@ func TestResolveVar_EnvFileScopedBeatsOpsfileUnscoped(t *testing.T) {
 func TestResolveVar_EnvFileScopedKeyWrongEnv(t *testing.T) {
 	// An env-file key scoped to a different env must not resolve for the current env.
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"echo $(VAR)"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo $(VAR)"}},
 		}},
 	}
 	envFileVars := OpsVariables{"staging_VAR": "wrong-env-value"}
-	_, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, envFileVars)
+	_, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, envFileVars, os.LookupEnv)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "not defined")
 }
 
-// --- @ prefix tests ---
+// --- @ (silent) prefix flag propagation tests ---
 
-func TestResolve_AtPrefixStripped(t *testing.T) {
+func TestResolve_SilentFlagPropagated(t *testing.T) {
+	// Verify resolver passes through Silent=true from ShellLine to ResolvedLine.
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"@echo hello"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo hello", Silent: true}},
 		}},
 	}
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "echo hello", got.Lines[0].Text)
 	assert.True(t, got.Lines[0].Silent)
 }
 
-func TestResolve_NoAtPrefix(t *testing.T) {
+func TestResolve_NoSilentFlag(t *testing.T) {
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"echo hello"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo hello"}},
 		}},
 	}
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "echo hello", got.Lines[0].Text)
 	assert.False(t, got.Lines[0].Silent)
 }
 
-func TestResolve_MixedAtAndNonAt(t *testing.T) {
+func TestResolve_MixedSilentAndNonSilent(t *testing.T) {
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"@echo setup", "aws deploy", "@echo cleanup"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {
+				{Text: "echo setup", Silent: true},
+				{Text: "aws deploy"},
+				{Text: "echo cleanup", Silent: true},
+			},
 		}},
 	}
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 3)
 	assert.Equal(t, "echo setup", got.Lines[0].Text)
@@ -593,7 +613,7 @@ my-cmd:
     default:
         @echo $(VAR)
 `)
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "echo hello", got.Lines[0].Text)
@@ -608,7 +628,7 @@ my-cmd:
     default:
         @echo $(ACCT)
 `)
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "echo 123", got.Lines[0].Text)
@@ -622,7 +642,7 @@ my-cmd:
         @aws logs \
             --follow
 `)
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "aws logs --follow", got.Lines[0].Text)
@@ -636,7 +656,7 @@ my-cmd:
         @aws logs
             --follow
 `)
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "aws logs --follow", got.Lines[0].Text)
@@ -644,12 +664,13 @@ my-cmd:
 }
 
 func TestResolve_DoubleAtPrefix(t *testing.T) {
+	// @@echo hello: parser strips first @, leaves @echo hello as text.
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"@@echo hello"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "@echo hello", Silent: true}},
 		}},
 	}
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "@echo hello", got.Lines[0].Text)
@@ -657,12 +678,13 @@ func TestResolve_DoubleAtPrefix(t *testing.T) {
 }
 
 func TestResolve_AtPrefixOnly(t *testing.T) {
+	// @ alone: silent flag, empty text.
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"@"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "", Silent: true}},
 		}},
 	}
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "", got.Lines[0].Text)
@@ -671,11 +693,11 @@ func TestResolve_AtPrefixOnly(t *testing.T) {
 
 func TestResolve_AtInMiddleOfLine(t *testing.T) {
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"echo user@host.com"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo user@host.com"}},
 		}},
 	}
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "echo user@host.com", got.Lines[0].Text)
@@ -690,7 +712,7 @@ my-cmd:
     default:
         echo $(VAR)
 `)
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Equal(t, "echo user@host", got.Lines[0].Text)
 	assert.False(t, got.Lines[0].Silent)
@@ -698,11 +720,11 @@ my-cmd:
 
 func TestResolve_AtPrefixNonIdentifierPassthrough(t *testing.T) {
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"@$(shell cmd)"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "$(shell cmd)", Silent: true}},
 		}},
 	}
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "$(shell cmd)", got.Lines[0].Text)
@@ -711,11 +733,11 @@ func TestResolve_AtPrefixNonIdentifierPassthrough(t *testing.T) {
 
 func TestResolve_AtPrefixMissingVariable(t *testing.T) {
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"@echo $(MISSING)"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo $(MISSING)", Silent: true}},
 		}},
 	}
-	_, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	_, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "not defined")
 }
@@ -728,7 +750,7 @@ my-cmd:
         echo deploy
         @echo cleanup
 `)
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 3)
 
@@ -745,9 +767,9 @@ func TestResolve_AtPrefixBackslashTrailingEOF(t *testing.T) {
 my-cmd:
     prod:
         @aws logs \`
-	_, commands, _, _, err := ParseOpsFile(writeTempOpsfile(t, content))
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
 	require.NoError(t, err)
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	got, err := Resolve("my-cmd", "prod", parsed.Commands, OpsVariables{}, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "aws logs ", got.Lines[0].Text)
@@ -763,7 +785,7 @@ my-cmd:
         aws logs \
             @--follow
 `)
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "aws logs @--follow", got.Lines[0].Text)
@@ -771,13 +793,13 @@ my-cmd:
 }
 
 func TestResolve_AtPrefixWhitespaceOnlyAfter(t *testing.T) {
-	// @ followed by only whitespace — silent flag set, text is the whitespace.
+	// Silent flag set, text is the whitespace.
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"@   "},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "   ", Silent: true}},
 		}},
 	}
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "   ", got.Lines[0].Text)
@@ -794,22 +816,22 @@ deploy:
         aws ecs update --region $(REGION)
         echo done
 `)
-	got, err := Resolve("deploy", "prod", commands, vars, nil)
+	got, err := Resolve("deploy", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	for i, line := range got.Lines {
 		assert.False(t, line.Silent, "line %d should not be silent", i)
 	}
 }
 
-// --- - (dash) prefix tests ---
+// --- - (dash / ignore-error) prefix flag propagation tests ---
 
-func TestResolve_DashPrefixStripped(t *testing.T) {
+func TestResolve_IgnoreErrorFlagPropagated(t *testing.T) {
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"-echo hello"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo hello", IgnoreError: true}},
 		}},
 	}
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "echo hello", got.Lines[0].Text)
@@ -817,13 +839,13 @@ func TestResolve_DashPrefixStripped(t *testing.T) {
 	assert.False(t, got.Lines[0].Silent)
 }
 
-func TestResolve_NoDashPrefix(t *testing.T) {
+func TestResolve_NoIgnoreErrorFlag(t *testing.T) {
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"echo hello"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo hello"}},
 		}},
 	}
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "echo hello", got.Lines[0].Text)
@@ -831,27 +853,13 @@ func TestResolve_NoDashPrefix(t *testing.T) {
 	assert.False(t, got.Lines[0].Silent)
 }
 
-func TestResolve_DashAtPrefix(t *testing.T) {
+func TestResolve_BothFlagsPropagated(t *testing.T) {
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"-@echo hello"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo hello", Silent: true, IgnoreError: true}},
 		}},
 	}
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
-	require.NoError(t, err)
-	require.Len(t, got.Lines, 1)
-	assert.Equal(t, "echo hello", got.Lines[0].Text)
-	assert.True(t, got.Lines[0].IgnoreError)
-	assert.True(t, got.Lines[0].Silent)
-}
-
-func TestResolve_AtDashPrefix(t *testing.T) {
-	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"@-echo hello"},
-		}},
-	}
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "echo hello", got.Lines[0].Text)
@@ -867,7 +875,7 @@ my-cmd:
     default:
         -echo $(VAR)
 `)
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "echo hello", got.Lines[0].Text)
@@ -882,7 +890,7 @@ my-cmd:
     default:
         -echo $(ACCT)
 `)
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "echo 123", got.Lines[0].Text)
@@ -896,7 +904,7 @@ my-cmd:
         -aws logs \
             --follow
 `)
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "aws logs --follow", got.Lines[0].Text)
@@ -910,20 +918,23 @@ my-cmd:
         -aws logs
             --follow
 `)
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "aws logs --follow", got.Lines[0].Text)
 	assert.True(t, got.Lines[0].IgnoreError)
 }
 
-func TestResolve_MixedDashAndNonDash(t *testing.T) {
+func TestResolve_MixedIgnoreErrorAndNormal(t *testing.T) {
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"-docker stop app", "docker run app"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {
+				{Text: "docker stop app", IgnoreError: true},
+				{Text: "docker run app"},
+			},
 		}},
 	}
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 2)
 	assert.Equal(t, "docker stop app", got.Lines[0].Text)
@@ -940,7 +951,7 @@ my-cmd:
         echo deploy
         -echo cleanup
 `)
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 3)
 
@@ -955,12 +966,13 @@ my-cmd:
 }
 
 func TestResolve_DoubleDashPrefix(t *testing.T) {
+	// --echo hello: parser strips first -, leaves -echo hello as text.
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"--echo hello"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "-echo hello", IgnoreError: true}},
 		}},
 	}
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "-echo hello", got.Lines[0].Text)
@@ -968,12 +980,13 @@ func TestResolve_DoubleDashPrefix(t *testing.T) {
 }
 
 func TestResolve_DashPrefixOnly(t *testing.T) {
+	// - alone: ignoreError flag, empty text.
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"-"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "", IgnoreError: true}},
 		}},
 	}
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "", got.Lines[0].Text)
@@ -982,12 +995,13 @@ func TestResolve_DashPrefixOnly(t *testing.T) {
 }
 
 func TestResolve_DashAtPrefixOnly(t *testing.T) {
+	// -@ alone: both flags, empty text.
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"-@"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "", Silent: true, IgnoreError: true}},
 		}},
 	}
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "", got.Lines[0].Text)
@@ -997,11 +1011,11 @@ func TestResolve_DashAtPrefixOnly(t *testing.T) {
 
 func TestResolve_DashInMiddleOfLine(t *testing.T) {
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"kubectl delete --force"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "kubectl delete --force"}},
 		}},
 	}
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "kubectl delete --force", got.Lines[0].Text)
@@ -1016,7 +1030,7 @@ my-cmd:
     default:
         echo $(VAR)
 `)
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	assert.Equal(t, "echo hello-world", got.Lines[0].Text)
 	assert.False(t, got.Lines[0].IgnoreError)
@@ -1029,7 +1043,7 @@ my-cmd:
         aws logs \
             -follow
 `)
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "aws logs -follow", got.Lines[0].Text)
@@ -1038,22 +1052,22 @@ my-cmd:
 
 func TestResolve_DashPrefixMissingVariable(t *testing.T) {
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"-echo $(MISSING)"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "echo $(MISSING)", IgnoreError: true}},
 		}},
 	}
-	_, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	_, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "not defined")
 }
 
 func TestResolve_DashPrefixWhitespaceAfter(t *testing.T) {
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"-   "},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "   ", IgnoreError: true}},
 		}},
 	}
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "   ", got.Lines[0].Text)
@@ -1067,7 +1081,7 @@ my-cmd:
         -@aws stop \
             --force
 `)
-	got, err := Resolve("my-cmd", "prod", commands, vars, nil)
+	got, err := Resolve("my-cmd", "prod", commands, vars, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "aws stop --force", got.Lines[0].Text)
@@ -1078,11 +1092,11 @@ my-cmd:
 func TestResolve_DashAtDashPrefix(t *testing.T) {
 	// -@- should strip one - and one @, leaving - as shell text
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"-@-echo hello"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "-echo hello", Silent: true, IgnoreError: true}},
 		}},
 	}
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "-echo hello", got.Lines[0].Text)
@@ -1093,11 +1107,11 @@ func TestResolve_DashAtDashPrefix(t *testing.T) {
 func TestResolve_AtDashAtPrefix(t *testing.T) {
 	// @-@ should strip one @ and one -, leaving @ as shell text
 	commands := map[string]OpsCommand{
-		"my-cmd": {Name: "my-cmd", Environments: map[string][]string{
-			"prod": {"@-@echo hello"},
+		"my-cmd": {Name: "my-cmd", Environments: map[string][]ShellLine{
+			"prod": {{Text: "@echo hello", Silent: true, IgnoreError: true}},
 		}},
 	}
-	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil)
+	got, err := Resolve("my-cmd", "prod", commands, OpsVariables{}, nil, os.LookupEnv)
 	require.NoError(t, err)
 	require.Len(t, got.Lines, 1)
 	assert.Equal(t, "@echo hello", got.Lines[0].Text)

--- a/internal/executor.go
+++ b/internal/executor.go
@@ -8,26 +8,52 @@ import (
 	"os/exec"
 )
 
+// DefaultShell returns the user's preferred shell from the SHELL environment
+// variable, falling back to /bin/sh if unset.
+func DefaultShell() string {
+	if s := os.Getenv("SHELL"); s != "" {
+		return s
+	}
+	return "/bin/sh"
+}
+
 // Execute runs each resolved shell line sequentially using the given shell
 // binary. Each command inherits the current process environment and has its
 // stdin/stdout/stderr connected to the terminal.
+//
+// commandArgs are passed as positional parameters to the shell ($1, $2, $@
+// inside the shell script). They are forwarded via the POSIX sh -c convention:
+// sh -c "script" -- arg1 arg2 ...
 //
 // When silent is false, each line's Text is printed to the echo writer before
 // execution — unless the line's Silent flag is set (from an @ prefix in the
 // Opsfile). When silent is true, no lines are echoed regardless of per-line
 // flags.
 //
+// When dryRun is true, lines are echoed (subject to silent/per-line flags) but
+// not executed. Execute returns nil in this case.
+//
 // When a line's IgnoreError flag is set (from a - prefix in the Opsfile),
 // non-zero exit codes from that line are ignored and execution continues.
 // System-level errors (e.g., shell not found) still propagate.
 //
 // Returns immediately on the first non-ignored command failure.
-func Execute(lines []ResolvedLine, shell string, silent bool, echo io.Writer) error {
+func Execute(lines []ResolvedLine, shell string, silent bool, dryRun bool, commandArgs []string, echo io.Writer) error {
+	if dryRun {
+		for _, line := range lines {
+			if !silent && !line.Silent {
+				fmt.Fprintln(echo, line.Text)
+			}
+		}
+		return nil
+	}
+
 	for _, line := range lines {
 		if !silent && !line.Silent {
 			fmt.Fprintln(echo, line.Text)
 		}
-		cmd := exec.Command(shell, "-c", line.Text)
+		args := append([]string{"-c", line.Text, "ops"}, commandArgs...)
+		cmd := exec.Command(shell, args...)
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr

--- a/internal/executor_test.go
+++ b/internal/executor_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"os"
 	"os/exec"
 	"testing"
 
@@ -67,7 +68,7 @@ func TestExecute(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := Execute(tc.lines, "/bin/sh", false, io.Discard)
+			err := Execute(tc.lines, "/bin/sh", false, false, nil, io.Discard)
 			if tc.wantErr {
 				require.Error(t, err)
 				var exitErr *exec.ExitError
@@ -81,24 +82,24 @@ func TestExecute(t *testing.T) {
 }
 
 func TestExecute_ErrorWrapsCommandString(t *testing.T) {
-	err := Execute(toLines("this-command-does-not-exist-at-all"), "/bin/sh", false, io.Discard)
+	err := Execute(toLines("this-command-does-not-exist-at-all"), "/bin/sh", false, false, nil, io.Discard)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "this-command-does-not-exist-at-all")
 }
 
 func TestExecute_InvalidShellPath(t *testing.T) {
-	err := Execute(toLines("echo hello"), "/nonexistent/shell/binary", false, io.Discard)
+	err := Execute(toLines("echo hello"), "/nonexistent/shell/binary", false, false, nil, io.Discard)
 	require.Error(t, err)
 }
 
 func TestExecute_CommandWithPipe(t *testing.T) {
-	err := Execute(toLines("echo hello | cat"), "/bin/sh", false, io.Discard)
+	err := Execute(toLines("echo hello | cat"), "/bin/sh", false, false, nil, io.Discard)
 	assert.NoError(t, err)
 }
 
 func TestExecute_StderrConnected(t *testing.T) {
 	// A command writing to stderr should not cause an error by itself.
-	err := Execute(toLines("echo error-output >&2"), "/bin/sh", false, io.Discard)
+	err := Execute(toLines("echo error-output >&2"), "/bin/sh", false, false, nil, io.Discard)
 	assert.NoError(t, err)
 }
 
@@ -108,7 +109,7 @@ func TestExecute_EchoesNonSilentLine(t *testing.T) {
 	var buf bytes.Buffer
 	err := Execute([]ResolvedLine{
 		{Text: "true", Silent: false},
-	}, "/bin/sh", false, &buf)
+	}, "/bin/sh", false, false, nil, &buf)
 	require.NoError(t, err)
 	assert.Equal(t, "true\n", buf.String())
 }
@@ -117,7 +118,7 @@ func TestExecute_SkipsSilentLine(t *testing.T) {
 	var buf bytes.Buffer
 	err := Execute([]ResolvedLine{
 		{Text: "true", Silent: true},
-	}, "/bin/sh", false, &buf)
+	}, "/bin/sh", false, false, nil, &buf)
 	require.NoError(t, err)
 	assert.Empty(t, buf.String())
 }
@@ -127,7 +128,7 @@ func TestExecute_GlobalSilentSuppressesAll(t *testing.T) {
 	err := Execute([]ResolvedLine{
 		{Text: "true", Silent: false},
 		{Text: "true", Silent: true},
-	}, "/bin/sh", true, &buf)
+	}, "/bin/sh", true, false, nil, &buf)
 	require.NoError(t, err)
 	assert.Empty(t, buf.String())
 }
@@ -138,7 +139,7 @@ func TestExecute_MixedSilentAndNonSilent(t *testing.T) {
 		{Text: "true", Silent: true},
 		{Text: "echo hello", Silent: false},
 		{Text: "true", Silent: true},
-	}, "/bin/sh", false, &buf)
+	}, "/bin/sh", false, false, nil, &buf)
 	require.NoError(t, err)
 	assert.Equal(t, "echo hello\n", buf.String())
 }
@@ -148,7 +149,7 @@ func TestExecute_EchoMultipleNonSilentLines(t *testing.T) {
 	err := Execute([]ResolvedLine{
 		{Text: "true", Silent: false},
 		{Text: "echo hi", Silent: false},
-	}, "/bin/sh", false, &buf)
+	}, "/bin/sh", false, false, nil, &buf)
 	require.NoError(t, err)
 	assert.Equal(t, "true\necho hi\n", buf.String())
 }
@@ -157,7 +158,7 @@ func TestExecute_AtPrefixOnFailingCommand(t *testing.T) {
 	var buf bytes.Buffer
 	err := Execute([]ResolvedLine{
 		{Text: "false", Silent: true},
-	}, "/bin/sh", false, &buf)
+	}, "/bin/sh", false, false, nil, &buf)
 	require.Error(t, err)
 	var exitErr *exec.ExitError
 	require.True(t, errors.As(err, &exitErr))
@@ -169,14 +170,14 @@ func TestExecute_AtPrefixInvalidShell(t *testing.T) {
 	var buf bytes.Buffer
 	err := Execute([]ResolvedLine{
 		{Text: "echo hello", Silent: true},
-	}, "/nonexistent/shell/binary", false, &buf)
+	}, "/nonexistent/shell/binary", false, false, nil, &buf)
 	require.Error(t, err)
 	assert.Empty(t, buf.String())
 }
 
 func TestExecute_EmptyLinesWithSilent(t *testing.T) {
 	var buf bytes.Buffer
-	err := Execute([]ResolvedLine{}, "/bin/sh", true, &buf)
+	err := Execute([]ResolvedLine{}, "/bin/sh", true, false, nil, &buf)
 	require.NoError(t, err)
 	assert.Empty(t, buf.String())
 }
@@ -188,7 +189,7 @@ func TestExecute_IgnoreErrorContinues(t *testing.T) {
 	err := Execute([]ResolvedLine{
 		{Text: "false", IgnoreError: true},
 		{Text: "true"},
-	}, "/bin/sh", false, &buf)
+	}, "/bin/sh", false, false, nil, &buf)
 	require.NoError(t, err)
 	assert.Equal(t, "false\ntrue\n", buf.String())
 }
@@ -196,14 +197,14 @@ func TestExecute_IgnoreErrorContinues(t *testing.T) {
 func TestExecute_IgnoreErrorExitCode42(t *testing.T) {
 	err := Execute([]ResolvedLine{
 		{Text: "exit 42", IgnoreError: true},
-	}, "/bin/sh", false, io.Discard)
+	}, "/bin/sh", false, false, nil, io.Discard)
 	assert.NoError(t, err)
 }
 
 func TestExecute_NonDashLineStillFails(t *testing.T) {
 	err := Execute([]ResolvedLine{
 		{Text: "false", IgnoreError: false},
-	}, "/bin/sh", false, io.Discard)
+	}, "/bin/sh", false, false, nil, io.Discard)
 	require.Error(t, err)
 	var exitErr *exec.ExitError
 	require.True(t, errors.As(err, &exitErr))
@@ -213,7 +214,7 @@ func TestExecute_NonDashLineStillFails(t *testing.T) {
 func TestExecute_IgnoreErrorInvalidShell(t *testing.T) {
 	err := Execute([]ResolvedLine{
 		{Text: "echo hi", IgnoreError: true},
-	}, "/nonexistent/shell/binary", false, io.Discard)
+	}, "/nonexistent/shell/binary", false, false, nil, io.Discard)
 	require.Error(t, err, "system-level error (shell not found) should not be ignored")
 }
 
@@ -221,7 +222,7 @@ func TestExecute_FailAfterIgnored(t *testing.T) {
 	err := Execute([]ResolvedLine{
 		{Text: "false", IgnoreError: true},
 		{Text: "false", IgnoreError: false},
-	}, "/bin/sh", false, io.Discard)
+	}, "/bin/sh", false, false, nil, io.Discard)
 	require.Error(t, err)
 	var exitErr *exec.ExitError
 	require.True(t, errors.As(err, &exitErr))
@@ -232,7 +233,7 @@ func TestExecute_IgnoreErrorAndSilent(t *testing.T) {
 	var buf bytes.Buffer
 	err := Execute([]ResolvedLine{
 		{Text: "false", IgnoreError: true, Silent: true},
-	}, "/bin/sh", false, &buf)
+	}, "/bin/sh", false, false, nil, &buf)
 	require.NoError(t, err)
 	assert.Empty(t, buf.String())
 }
@@ -241,7 +242,7 @@ func TestExecute_IgnoreErrorWithGlobalSilent(t *testing.T) {
 	var buf bytes.Buffer
 	err := Execute([]ResolvedLine{
 		{Text: "false", IgnoreError: true},
-	}, "/bin/sh", true, &buf)
+	}, "/bin/sh", true, false, nil, &buf)
 	require.NoError(t, err)
 	assert.Empty(t, buf.String())
 }
@@ -251,7 +252,7 @@ func TestExecute_AllLinesIgnoreError(t *testing.T) {
 		{Text: "false", IgnoreError: true},
 		{Text: "exit 2", IgnoreError: true},
 		{Text: "exit 127", IgnoreError: true},
-	}, "/bin/sh", false, io.Discard)
+	}, "/bin/sh", false, false, nil, io.Discard)
 	assert.NoError(t, err)
 }
 
@@ -259,7 +260,7 @@ func TestExecute_IgnoreErrorEchoStillShows(t *testing.T) {
 	var buf bytes.Buffer
 	err := Execute([]ResolvedLine{
 		{Text: "false", IgnoreError: true, Silent: false},
-	}, "/bin/sh", false, &buf)
+	}, "/bin/sh", false, false, nil, &buf)
 	require.NoError(t, err)
 	assert.Equal(t, "false\n", buf.String())
 }
@@ -269,6 +270,189 @@ func TestExecute_IgnoreErrorCommandNotFound(t *testing.T) {
 	// so it should be ignored when IgnoreError is true.
 	err := Execute([]ResolvedLine{
 		{Text: "nonexistent-binary-xyz-12345", IgnoreError: true},
-	}, "/bin/sh", false, io.Discard)
+	}, "/bin/sh", false, false, nil, io.Discard)
 	assert.NoError(t, err)
+}
+
+// --- DryRun behavior tests ---
+
+func TestExecute_DryRunDoesNotExecute(t *testing.T) {
+	// A failing command should not produce an error in dry-run mode.
+	err := Execute(toLines("exit 1"), "/bin/sh", false, true, nil, io.Discard)
+	assert.NoError(t, err)
+}
+
+func TestExecute_DryRunPrintsLines(t *testing.T) {
+	var buf bytes.Buffer
+	err := Execute([]ResolvedLine{
+		{Text: "echo hello"},
+		{Text: "echo world"},
+	}, "/bin/sh", false, true, nil, &buf)
+	require.NoError(t, err)
+	assert.Equal(t, "echo hello\necho world\n", buf.String())
+}
+
+func TestExecute_DryRunGlobalSilentSuppressesAll(t *testing.T) {
+	var buf bytes.Buffer
+	err := Execute([]ResolvedLine{
+		{Text: "echo hello"},
+		{Text: "echo world"},
+	}, "/bin/sh", true, true, nil, &buf)
+	require.NoError(t, err)
+	assert.Empty(t, buf.String())
+}
+
+func TestExecute_DryRunPerLineSilentSuppressed(t *testing.T) {
+	var buf bytes.Buffer
+	err := Execute([]ResolvedLine{
+		{Text: "echo visible"},
+		{Text: "echo hidden", Silent: true},
+	}, "/bin/sh", false, true, nil, &buf)
+	require.NoError(t, err)
+	assert.Equal(t, "echo visible\n", buf.String())
+}
+
+func TestExecute_DryRunEmptyLines(t *testing.T) {
+	var buf bytes.Buffer
+	err := Execute([]ResolvedLine{}, "/bin/sh", false, true, nil, &buf)
+	require.NoError(t, err)
+	assert.Empty(t, buf.String())
+}
+
+// --- CommandArgs passthrough tests (Finding #7) ---
+
+func TestExecute_CommandArgsPositional(t *testing.T) {
+	// sh -c "echo $1 $2" -- hello world → file should contain "hello world"
+	tmpFile := t.TempDir() + "/out.txt"
+	err := Execute([]ResolvedLine{
+		{Text: "echo $1 $2 > " + tmpFile},
+	}, "/bin/sh", true, false, []string{"hello", "world"}, io.Discard)
+	require.NoError(t, err)
+	content, err := os.ReadFile(tmpFile)
+	require.NoError(t, err)
+	assert.Equal(t, "hello world\n", string(content))
+}
+
+func TestExecute_CommandArgsAt(t *testing.T) {
+	// Use a temp file to capture side-effects from the shell command.
+	tmpFile := t.TempDir() + "/args.txt"
+	err := Execute([]ResolvedLine{
+		{Text: "echo $@ > " + tmpFile},
+	}, "/bin/sh", true, false, []string{"a", "b", "c"}, io.Discard)
+	require.NoError(t, err)
+	content, err := os.ReadFile(tmpFile)
+	require.NoError(t, err)
+	assert.Equal(t, "a b c\n", string(content))
+}
+
+func TestExecute_CommandArgsFirst(t *testing.T) {
+	tmpFile := t.TempDir() + "/arg1.txt"
+	err := Execute([]ResolvedLine{
+		{Text: "echo $1 > " + tmpFile},
+	}, "/bin/sh", true, false, []string{"first", "second"}, io.Discard)
+	require.NoError(t, err)
+	content, err := os.ReadFile(tmpFile)
+	require.NoError(t, err)
+	assert.Equal(t, "first\n", string(content))
+}
+
+func TestExecute_EmptyCommandArgsNoEffect(t *testing.T) {
+	// Passing nil/empty commandArgs should not affect commands that don't use $@.
+	err := Execute(toLines("true"), "/bin/sh", false, false, nil, io.Discard)
+	assert.NoError(t, err)
+
+	err = Execute(toLines("true"), "/bin/sh", false, false, []string{}, io.Discard)
+	assert.NoError(t, err)
+}
+
+func TestExecute_CommandArgsWithMultipleLines(t *testing.T) {
+	tmpFile := t.TempDir() + "/out.txt"
+	// Args should be available on every line in the sequence.
+	err := Execute([]ResolvedLine{
+		{Text: "echo $1 >> " + tmpFile},
+		{Text: "echo $2 >> " + tmpFile},
+	}, "/bin/sh", true, false, []string{"line1", "line2"}, io.Discard)
+	require.NoError(t, err)
+	content, err := os.ReadFile(tmpFile)
+	require.NoError(t, err)
+	assert.Equal(t, "line1\nline2\n", string(content))
+}
+
+func TestExecute_CommandArgsDryRunDoesNotPassArgs(t *testing.T) {
+	// In dry-run mode, no execution occurs so args don't matter —
+	// only the echo output is produced.
+	var buf bytes.Buffer
+	err := Execute([]ResolvedLine{
+		{Text: "echo $1"},
+	}, "/bin/sh", false, true, []string{"unused"}, &buf)
+	require.NoError(t, err)
+	// dry-run echoes the unreplaced shell text, not the resolved arg value.
+	assert.Equal(t, "echo $1\n", buf.String())
+}
+
+func TestExecute_CommandArgsWithSpacesInArg(t *testing.T) {
+	// A single arg containing spaces should arrive in $1 as one unit.
+	tmpFile := t.TempDir() + "/out.txt"
+	err := Execute([]ResolvedLine{
+		{Text: `echo "$1" > ` + tmpFile},
+	}, "/bin/sh", true, false, []string{"hello world"}, io.Discard)
+	require.NoError(t, err)
+	content, err := os.ReadFile(tmpFile)
+	require.NoError(t, err)
+	assert.Equal(t, "hello world\n", string(content))
+}
+
+func TestExecute_DoubleDashLinePrefixStrippedToSingleDash(t *testing.T) {
+	// When an Opsfile line starts with "--something" the parser strips one "-"
+	// leaving "-something" with IgnoreError=true (see TestParseOpsFile_DoubleDashPrefixParsed).
+	// "-something" is not a valid shell command, so the shell returns exit 127.
+	// With IgnoreError=true that failure is swallowed and execution continues.
+	// This test documents the end-to-end behavior of that edge case.
+	err := Execute([]ResolvedLine{
+		{Text: "-this-is-not-a-command", IgnoreError: true},
+		{Text: "true"},
+	}, "/bin/sh", false, false, nil, io.Discard)
+	assert.NoError(t, err, "IgnoreError should swallow the exit 127 from the unknown command")
+}
+
+func TestExecute_CommandArgsDollarZeroIsOps(t *testing.T) {
+	// POSIX convention: sh -c "script" name arg1 arg2...
+	// The string after the script becomes $0 inside the shell.
+	// We use "ops" so users who reference $0 see a meaningful program name.
+	tmpFile := t.TempDir() + "/out.txt"
+	err := Execute([]ResolvedLine{
+		{Text: "echo $0 > " + tmpFile},
+	}, "/bin/sh", true, false, []string{"myapp"}, io.Discard)
+	require.NoError(t, err)
+	content, err := os.ReadFile(tmpFile)
+	require.NoError(t, err)
+	assert.Equal(t, "ops\n", string(content))
+}
+
+// --- DefaultShell tests ---
+
+func TestDefaultShell_ReturnsNonEmpty(t *testing.T) {
+	shell := DefaultShell()
+	assert.NotEmpty(t, shell)
+}
+
+func TestDefaultShell_FallbackWhenUnset(t *testing.T) {
+	t.Setenv("SHELL", "")
+	shell := DefaultShell()
+	assert.Equal(t, "/bin/sh", shell)
+}
+
+func TestDefaultShell_UsesShellEnvVar(t *testing.T) {
+	t.Setenv("SHELL", "/bin/bash")
+	shell := DefaultShell()
+	assert.Equal(t, "/bin/bash", shell)
+}
+
+func TestDefaultShell_ReturnsShellVerbatimEvenIfInvalid(t *testing.T) {
+	// DefaultShell is a pure string reader — it returns whatever $SHELL
+	// contains without validating the path. An invalid path will fail at
+	// Execute time, not here.
+	t.Setenv("SHELL", "/nonexistent/my-shell")
+	shell := DefaultShell()
+	assert.Equal(t, "/nonexistent/my-shell", shell)
 }

--- a/internal/opsfile_parser.go
+++ b/internal/opsfile_parser.go
@@ -14,13 +14,29 @@ import (
 // Environment-scoped variable resolution is deferred to execution time.
 type OpsVariables map[string]string
 
+// ShellLine is a single shell line as parsed from an Opsfile environment block,
+// with per-line metadata extracted at parse time.
+type ShellLine struct {
+	Text        string
+	Silent      bool // from @ prefix
+	IgnoreError bool // from - prefix
+}
+
 // OpsCommand represents a single named command with per-environment shell lines.
 type OpsCommand struct {
 	Name        string
 	Description string // from # comment directly above declaration
 	// Environments maps environment name to the ordered list of shell lines to execute.
 	// "default" is a valid key used as a fallback at execution time.
-	Environments map[string][]string
+	Environments map[string][]ShellLine
+}
+
+// ParsedOpsfile holds the complete result of parsing an Opsfile.
+type ParsedOpsfile struct {
+	Variables    OpsVariables
+	Commands     map[string]OpsCommand
+	CommandOrder []string
+	EnvOrder     []string
 }
 
 type parseState int
@@ -48,12 +64,12 @@ type parser struct {
 }
 
 // ParseOpsFile reads and parses an Opsfile at the given path.
-// It returns the declared variables, commands, command declaration order,
-// environment declaration order, and any error.
-func ParseOpsFile(path string) (OpsVariables, map[string]OpsCommand, []string, []string, error) {
+// It returns a ParsedOpsfile containing the declared variables, commands,
+// command declaration order, and environment declaration order.
+func ParseOpsFile(path string) (ParsedOpsfile, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("opening Opsfile: %w", err)
+		return ParsedOpsfile{}, fmt.Errorf("opening Opsfile: %w", err)
 	}
 	defer f.Close()
 
@@ -65,25 +81,30 @@ func ParseOpsFile(path string) (OpsVariables, map[string]OpsCommand, []string, [
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		if err := p.processLine(scanner.Text()); err != nil {
-			return nil, nil, nil, nil, fmt.Errorf("line %d: %w", p.lineNum, err)
+			return ParsedOpsfile{}, fmt.Errorf("line %d: %w", p.lineNum, err)
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("reading Opsfile: %w", err)
+		return ParsedOpsfile{}, fmt.Errorf("reading Opsfile: %w", err)
 	}
 
 	// Flush any trailing backslash-continuation fragment at end of file.
 	p.flushContinuation()
 
 	if err := p.validate(); err != nil {
-		return nil, nil, nil, nil, err
+		return ParsedOpsfile{}, err
 	}
 
 	commands := make(map[string]OpsCommand, len(p.commands))
 	for k, v := range p.commands {
 		commands[k] = *v
 	}
-	return p.variables, commands, p.order, p.envOrder, nil
+	return ParsedOpsfile{
+		Variables:    p.variables,
+		Commands:     commands,
+		CommandOrder: p.order,
+		EnvOrder:     p.envOrder,
+	}, nil
 }
 
 // processLine categorises a raw line and dispatches to the appropriate handler.
@@ -233,7 +254,7 @@ func (p *parser) startCommand(name string) error {
 	p.commands[name] = &OpsCommand{
 		Name:         name,
 		Description:  p.lastComment,
-		Environments: make(map[string][]string),
+		Environments: make(map[string][]ShellLine),
 	}
 	p.lastComment = ""
 	p.order = append(p.order, name)
@@ -245,7 +266,7 @@ func (p *parser) startEnv(name string) {
 	p.currentEnv = name
 	cmd := p.commands[p.currentCommand]
 	if _, exists := cmd.Environments[name]; !exists {
-		cmd.Environments[name] = []string{}
+		cmd.Environments[name] = []ShellLine{}
 	}
 	if !slices.Contains(p.envOrder, name) {
 		p.envOrder = append(p.envOrder, name)
@@ -254,9 +275,35 @@ func (p *parser) startEnv(name string) {
 	p.state = inEnvironment
 }
 
-func (p *parser) appendShellLine(line string) {
+// appendShellLine strips any leading @ (silent) and - (ignore-error) prefixes
+// from the assembled shell line text and appends a ShellLine to the current
+// environment. Prefixes are only recognised at the very start of the line;
+// each prefix type is consumed at most once.
+func (p *parser) appendShellLine(raw string) {
+	silent := false
+	ignoreError := false
+	line := raw
+	for len(line) > 0 {
+		switch line[0] {
+		case '@':
+			if !silent {
+				silent = true
+				line = line[1:]
+				continue
+			}
+		case '-':
+			if !ignoreError {
+				ignoreError = true
+				line = line[1:]
+				continue
+			}
+		}
+		break
+	}
 	cmd := p.commands[p.currentCommand]
-	cmd.Environments[p.currentEnv] = append(cmd.Environments[p.currentEnv], line)
+	cmd.Environments[p.currentEnv] = append(cmd.Environments[p.currentEnv], ShellLine{
+		Text: line, Silent: silent, IgnoreError: ignoreError,
+	})
 }
 
 // flushContinuation appends any buffered backslash-continuation fragments as a
@@ -268,11 +315,12 @@ func (p *parser) flushContinuation() {
 	}
 }
 
-// joinLastShellLine appends suffix to the last shell line in the current environment.
+// joinLastShellLine appends suffix to the Text of the last shell line in the
+// current environment.
 func (p *parser) joinLastShellLine(suffix string) {
 	lines := p.commands[p.currentCommand].Environments[p.currentEnv]
 	if len(lines) > 0 {
-		lines[len(lines)-1] += suffix
+		lines[len(lines)-1].Text += suffix
 	}
 }
 

--- a/internal/opsfile_parser_test.go
+++ b/internal/opsfile_parser_test.go
@@ -20,7 +20,7 @@ func TestParseExamples_AllFilesParseWithoutError(t *testing.T) {
 
 	for _, path := range files {
 		t.Run(filepath.Base(path), func(t *testing.T) {
-			_, _, _, _, err := ParseOpsFile(path)
+			_, err := ParseOpsFile(path)
 			assert.NoError(t, err)
 		})
 	}
@@ -46,7 +46,7 @@ func examplesOpsfile(t *testing.T) string {
 }
 
 func TestParseOpsFile_Variables(t *testing.T) {
-	vars, _, _, _, err := ParseOpsFile(examplesOpsfile(t))
+	parsed, err := ParseOpsFile(examplesOpsfile(t))
 	require.NoError(t, err)
 
 	cases := []struct{ name, want string }{
@@ -54,26 +54,26 @@ func TestParseOpsFile_Variables(t *testing.T) {
 		{"preprod_AWS_ACCOUNT", "987654321098"},
 	}
 	for _, tc := range cases {
-		got, ok := vars[tc.name]
+		got, ok := parsed.Variables[tc.name]
 		require.True(t, ok, "variable %q not found", tc.name)
 		assert.Equal(t, tc.want, got, "variable %q", tc.name)
 	}
 }
 
 func TestParseOpsFile_NoComments(t *testing.T) {
-	vars, commands, _, _, err := ParseOpsFile(examplesOpsfile(t))
+	parsed, err := ParseOpsFile(examplesOpsfile(t))
 	require.NoError(t, err)
 
-	for k, v := range vars {
+	for k, v := range parsed.Variables {
 		if len(k) > 0 && k[0] == '#' {
 			t.Errorf("comment leaked into variables: key=%q value=%q", k, v)
 		}
 	}
-	for _, cmd := range commands {
+	for _, cmd := range parsed.Commands {
 		for env, lines := range cmd.Environments {
 			for _, line := range lines {
-				if len(line) > 0 && line[0] == '#' {
-					t.Errorf("comment leaked into command %q env %q: %q", cmd.Name, env, line)
+				if len(line.Text) > 0 && line.Text[0] == '#' {
+					t.Errorf("comment leaked into command %q env %q: %q", cmd.Name, env, line.Text)
 				}
 			}
 		}
@@ -81,24 +81,24 @@ func TestParseOpsFile_NoComments(t *testing.T) {
 }
 
 func TestParseOpsFile_Commands(t *testing.T) {
-	_, commands, _, _, err := ParseOpsFile(examplesOpsfile(t))
+	parsed, err := ParseOpsFile(examplesOpsfile(t))
 	require.NoError(t, err)
 
 	expectedCommands := []string{"tail-logs", "list-instance-ips", "show-profile", "redeploy"}
 	for _, name := range expectedCommands {
-		cmd, ok := commands[name]
+		cmd, ok := parsed.Commands[name]
 		require.True(t, ok, "command %q not found", name)
 		assert.Equal(t, name, cmd.Name, "command Name field")
 	}
 
-	assert.Len(t, commands, len(expectedCommands))
+	assert.Len(t, parsed.Commands, len(expectedCommands))
 }
 
 func TestParseOpsFile_TailLogsEnvironments(t *testing.T) {
-	_, commands, _, _, err := ParseOpsFile(examplesOpsfile(t))
+	parsed, err := ParseOpsFile(examplesOpsfile(t))
 	require.NoError(t, err)
 
-	cmd, ok := commands["tail-logs"]
+	cmd, ok := parsed.Commands["tail-logs"]
 	require.True(t, ok, "command 'tail-logs' not found")
 
 	// Should have "default" and "local" environments
@@ -109,19 +109,19 @@ func TestParseOpsFile_TailLogsEnvironments(t *testing.T) {
 	// default environment: 4 backslash-continuation lines join into 1
 	defaultLines := cmd.Environments["default"]
 	require.Len(t, defaultLines, 1, "tail-logs/default: expected 1 line")
-	assert.Equal(t, "aws logs tail $(LOG_GROUP) --follow --since 10m --region $(AWS_REGION)", defaultLines[0])
+	assert.Equal(t, "aws logs tail $(LOG_GROUP) --follow --since 10m --region $(AWS_REGION)", defaultLines[0].Text)
 
 	// local environment should have 1 shell line
 	localLines := cmd.Environments["local"]
 	require.Len(t, localLines, 1, "tail-logs/local: expected 1 line")
-	assert.Equal(t, "docker logs my-service --follow --tail 100", localLines[0])
+	assert.Equal(t, "docker logs my-service --follow --tail 100", localLines[0].Text)
 }
 
 func TestParseOpsFile_ListInstanceIpsEnvironments(t *testing.T) {
-	_, commands, _, _, err := ParseOpsFile(examplesOpsfile(t))
+	parsed, err := ParseOpsFile(examplesOpsfile(t))
 	require.NoError(t, err)
 
-	cmd, ok := commands["list-instance-ips"]
+	cmd, ok := parsed.Commands["list-instance-ips"]
 	require.True(t, ok, "command 'list-instance-ips' not found")
 
 	for _, env := range []string{"prod", "preprod"} {
@@ -137,7 +137,7 @@ func TestParseOpsFile_ListInstanceIpsEnvironments(t *testing.T) {
 }
 
 func TestParseOpsFile_FileNotFound(t *testing.T) {
-	_, _, _, _, err := ParseOpsFile("/nonexistent/path/Opsfile")
+	_, err := ParseOpsFile("/nonexistent/path/Opsfile")
 	require.Error(t, err)
 }
 
@@ -192,7 +192,7 @@ my-cmd:
     prod:
         aws something
 `
-	vars, _, _, _, err := ParseOpsFile(writeTempOpsfile(t, content))
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
 	require.NoError(t, err)
 	cases := []struct{ name, want string }{
 		{"PLAIN", "123"},
@@ -201,7 +201,7 @@ my-cmd:
 		{"NOSPACE", "val#notcomment"},
 	}
 	for _, tc := range cases {
-		assert.Equal(t, tc.want, vars[tc.name], "variable %q", tc.name)
+		assert.Equal(t, tc.want, parsed.Variables[tc.name], "variable %q", tc.name)
 	}
 }
 
@@ -213,20 +213,20 @@ my-cmd:
     prod:
         aws something
 `
-	_, _, _, _, err := ParseOpsFile(writeTempOpsfile(t, content))
+	_, err := ParseOpsFile(writeTempOpsfile(t, content))
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "unclosed")
 }
 
 func TestParseOpsFile_EmptyFile(t *testing.T) {
-	_, _, _, _, err := ParseOpsFile(writeTempOpsfile(t, ""))
+	_, err := ParseOpsFile(writeTempOpsfile(t, ""))
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "empty")
 }
 
 func TestParseOpsFile_OnlyComments(t *testing.T) {
 	content := "# just a comment\n# another comment\n"
-	_, _, _, _, err := ParseOpsFile(writeTempOpsfile(t, content))
+	_, err := ParseOpsFile(writeTempOpsfile(t, content))
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "empty")
 }
@@ -241,7 +241,7 @@ my-cmd:
     preprod:
         aws ecs something
 `
-	_, _, _, _, err := ParseOpsFile(writeTempOpsfile(t, content))
+	_, err := ParseOpsFile(writeTempOpsfile(t, content))
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "duplicate")
 }
@@ -254,7 +254,7 @@ my-cmd:
     prod:
         aws something
 `
-	_, _, _, _, err := ParseOpsFile(writeTempOpsfile(t, content))
+	_, err := ParseOpsFile(writeTempOpsfile(t, content))
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "missing name")
 }
@@ -266,11 +266,11 @@ my-cmd:
         aws cloudwatch logs \
             --log-group /my/group
 `
-	_, commands, _, _, err := ParseOpsFile(writeTempOpsfile(t, content))
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
 	require.NoError(t, err)
-	lines := commands["my-cmd"].Environments["prod"]
+	lines := parsed.Commands["my-cmd"].Environments["prod"]
 	require.Len(t, lines, 1)
-	assert.Equal(t, "aws cloudwatch logs --log-group /my/group", lines[0])
+	assert.Equal(t, "aws cloudwatch logs --log-group /my/group", lines[0].Text)
 }
 
 func TestParseOpsFile_BackslashContinuationChain(t *testing.T) {
@@ -281,11 +281,11 @@ my-cmd:
             --log-group /my/group \
             --tail
 `
-	_, commands, _, _, err := ParseOpsFile(writeTempOpsfile(t, content))
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
 	require.NoError(t, err)
-	lines := commands["my-cmd"].Environments["prod"]
+	lines := parsed.Commands["my-cmd"].Environments["prod"]
 	require.Len(t, lines, 1)
-	assert.Equal(t, "aws cloudwatch logs --log-group /my/group --tail", lines[0])
+	assert.Equal(t, "aws cloudwatch logs --log-group /my/group --tail", lines[0].Text)
 }
 
 func TestParseOpsFile_BackslashSpaceBeforeSlash(t *testing.T) {
@@ -295,11 +295,11 @@ my-cmd:
         aws logs \
             --tail
 `
-	_, commands, _, _, err := ParseOpsFile(writeTempOpsfile(t, content))
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
 	require.NoError(t, err)
-	lines := commands["my-cmd"].Environments["prod"]
+	lines := parsed.Commands["my-cmd"].Environments["prod"]
 	require.Len(t, lines, 1)
-	assert.Equal(t, "aws logs --tail", lines[0])
+	assert.Equal(t, "aws logs --tail", lines[0].Text)
 }
 
 func TestParseOpsFile_IndentContinuation(t *testing.T) {
@@ -309,11 +309,11 @@ my-cmd:
         aws cloudwatch logs
             --log-group /my/group
 `
-	_, commands, _, _, err := ParseOpsFile(writeTempOpsfile(t, content))
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
 	require.NoError(t, err)
-	lines := commands["my-cmd"].Environments["prod"]
+	lines := parsed.Commands["my-cmd"].Environments["prod"]
 	require.Len(t, lines, 1)
-	assert.Equal(t, "aws cloudwatch logs --log-group /my/group", lines[0])
+	assert.Equal(t, "aws cloudwatch logs --log-group /my/group", lines[0].Text)
 }
 
 func TestParseOpsFile_IndentContinuationChain(t *testing.T) {
@@ -324,11 +324,11 @@ my-cmd:
             --log-group /my/group
             --tail
 `
-	_, commands, _, _, err := ParseOpsFile(writeTempOpsfile(t, content))
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
 	require.NoError(t, err)
-	lines := commands["my-cmd"].Environments["prod"]
+	lines := parsed.Commands["my-cmd"].Environments["prod"]
 	require.Len(t, lines, 1)
-	assert.Equal(t, "aws cloudwatch logs --log-group /my/group --tail", lines[0])
+	assert.Equal(t, "aws cloudwatch logs --log-group /my/group --tail", lines[0].Text)
 }
 
 func TestParseOpsFile_IndentNewCommandAfterContinuation(t *testing.T) {
@@ -339,20 +339,20 @@ my-cmd:
             --log-group /my/group
         echo done
 `
-	_, commands, _, _, err := ParseOpsFile(writeTempOpsfile(t, content))
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
 	require.NoError(t, err)
-	lines := commands["my-cmd"].Environments["prod"]
+	lines := parsed.Commands["my-cmd"].Environments["prod"]
 	require.Len(t, lines, 2)
-	assert.Equal(t, "aws cloudwatch logs --log-group /my/group", lines[0])
-	assert.Equal(t, "echo done", lines[1])
+	assert.Equal(t, "aws cloudwatch logs --log-group /my/group", lines[0].Text)
+	assert.Equal(t, "echo done", lines[1].Text)
 }
 
 func TestParseOpsFile_VariableWhitespaceOnlyValue(t *testing.T) {
 	content := "VAR=   \n\nmy-cmd:\n    prod:\n        echo hello\n"
-	vars, _, _, _, err := ParseOpsFile(writeTempOpsfile(t, content))
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
 	require.NoError(t, err)
 	// TrimSpace on the value after "=" yields empty string.
-	assert.Equal(t, "", vars["VAR"])
+	assert.Equal(t, "", parsed.Variables["VAR"])
 }
 
 func TestParseOpsFile_VariableEmptyUnquotedValue(t *testing.T) {
@@ -363,9 +363,9 @@ my-cmd:
     prod:
         echo hello
 `
-	vars, _, _, _, err := ParseOpsFile(writeTempOpsfile(t, content))
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
 	require.NoError(t, err)
-	assert.Equal(t, "", vars["VAR"])
+	assert.Equal(t, "", parsed.Variables["VAR"])
 }
 
 func TestParseOpsFile_MultipleEnvironments(t *testing.T) {
@@ -380,13 +380,13 @@ my-cmd:
     default:
         echo default
 `
-	_, commands, _, _, err := ParseOpsFile(writeTempOpsfile(t, content))
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
 	require.NoError(t, err)
-	cmd := commands["my-cmd"]
+	cmd := parsed.Commands["my-cmd"]
 	for _, env := range []string{"prod", "preprod", "local", "default"} {
 		lines, ok := cmd.Environments[env]
 		require.True(t, ok, "environment %q not found", env)
-		assert.Equal(t, []string{"echo " + env}, lines, "env %q", env)
+		assert.Equal(t, []ShellLine{{Text: "echo " + env}}, lines, "env %q", env)
 	}
 }
 
@@ -398,41 +398,45 @@ my-cmd:
             --follow
             --since 10m
 `
-	_, commands, _, _, err := ParseOpsFile(writeTempOpsfile(t, content))
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
 	require.NoError(t, err)
-	lines := commands["my-cmd"].Environments["prod"]
+	lines := parsed.Commands["my-cmd"].Environments["prod"]
 	// Backslash joins first two into one line; the third line at same indent
 	// is NOT deeper than the flushed continuation, so it's a separate shell line.
 	require.Len(t, lines, 2)
-	assert.Equal(t, "aws logs tail --follow", lines[0])
-	assert.Equal(t, "--since 10m", lines[1])
+	assert.Equal(t, "aws logs tail --follow", lines[0].Text)
+	// "--since 10m" starts with '-' so the parser strips it as IgnoreError prefix,
+	// leaving "-since 10m" as the shell text — same end result as before (resolver
+	// previously did this stripping).
+	assert.Equal(t, "-since 10m", lines[1].Text)
+	assert.True(t, lines[1].IgnoreError)
 }
 
 func TestParseOpsFile_TabIndentedShellLines(t *testing.T) {
 	content := "my-cmd:\n\tprod:\n\t\techo hello\n\t\techo world\n"
-	_, commands, _, _, err := ParseOpsFile(writeTempOpsfile(t, content))
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
 	require.NoError(t, err)
-	lines := commands["my-cmd"].Environments["prod"]
+	lines := parsed.Commands["my-cmd"].Environments["prod"]
 	require.Len(t, lines, 2)
-	assert.Equal(t, "echo hello", lines[0])
-	assert.Equal(t, "echo world", lines[1])
+	assert.Equal(t, "echo hello", lines[0].Text)
+	assert.Equal(t, "echo world", lines[1].Text)
 }
 
 func TestParseOpsFile_CommandHeaderTrailingWhitespace(t *testing.T) {
 	// Trailing spaces after ":" should still parse as a command header.
 	// Note: TrimSpace strips trailing whitespace, so "my-cmd:  " -> "my-cmd:"
 	content := "my-cmd:  \n    prod:\n        echo hello\n"
-	_, commands, _, _, err := ParseOpsFile(writeTempOpsfile(t, content))
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
 	require.NoError(t, err)
-	assert.Contains(t, commands, "my-cmd")
+	assert.Contains(t, parsed.Commands, "my-cmd")
 }
 
 func TestParseOpsFile_EnvHeaderTrailingWhitespace(t *testing.T) {
 	// Trailing whitespace on env header line.
 	content := "my-cmd:\n    prod:  \n        echo hello\n"
-	_, commands, _, _, err := ParseOpsFile(writeTempOpsfile(t, content))
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
 	require.NoError(t, err)
-	assert.Contains(t, commands["my-cmd"].Environments, "prod")
+	assert.Contains(t, parsed.Commands["my-cmd"].Environments, "prod")
 }
 
 func TestParseOpsFile_VariableValueLeadingWhitespace(t *testing.T) {
@@ -443,10 +447,10 @@ my-cmd:
     prod:
         echo hello
 `
-	vars, _, _, _, err := ParseOpsFile(writeTempOpsfile(t, content))
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
 	require.NoError(t, err)
 	// parseVariable does TrimSpace on the value after "=", so "  value" -> "value"
-	assert.Equal(t, "value", vars["VAR"])
+	assert.Equal(t, "value", parsed.Variables["VAR"])
 }
 
 func TestParseOpsFile_LineNumberInParseError(t *testing.T) {
@@ -458,7 +462,7 @@ my-cmd:
     prod:
         echo hello
 `
-	_, _, _, _, err := ParseOpsFile(writeTempOpsfile(t, content))
+	_, err := ParseOpsFile(writeTempOpsfile(t, content))
 	require.Error(t, err)
 	// The unclosed quote is on line 3 (blank line 1, GOOD=fine line 2, BAD=... line 3).
 	assert.ErrorContains(t, err, "line 3")
@@ -469,12 +473,12 @@ func TestParseOpsFile_BackslashTrailingEOF(t *testing.T) {
 my-cmd:
     prod:
         aws cloudwatch logs \`
-	_, commands, _, _, err := ParseOpsFile(writeTempOpsfile(t, content))
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
 	require.NoError(t, err)
-	lines := commands["my-cmd"].Environments["prod"]
+	lines := parsed.Commands["my-cmd"].Environments["prod"]
 	require.Len(t, lines, 1)
 	// The trailing \ is stripped; what remains is the fragment before it.
-	assert.Equal(t, "aws cloudwatch logs ", lines[0])
+	assert.Equal(t, "aws cloudwatch logs ", lines[0].Text)
 }
 
 func TestParseOpsFile_Description(t *testing.T) {
@@ -525,9 +529,9 @@ deploy:
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, commands, _, _, err := ParseOpsFile(writeTempOpsfile(t, tc.content))
+			parsed, err := ParseOpsFile(writeTempOpsfile(t, tc.content))
 			require.NoError(t, err)
-			assert.Equal(t, tc.wantDesc, commands["deploy"].Description)
+			assert.Equal(t, tc.wantDesc, parsed.Commands["deploy"].Description)
 		})
 	}
 }
@@ -548,9 +552,9 @@ bravo:
     default:
         echo bravo
 `
-	_, _, cmdOrder, _, err := ParseOpsFile(writeTempOpsfile(t, content))
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
 	require.NoError(t, err)
-	assert.Equal(t, []string{"alpha", "charlie", "bravo"}, cmdOrder)
+	assert.Equal(t, []string{"alpha", "charlie", "bravo"}, parsed.CommandOrder)
 }
 
 func TestParseOpsFile_EnvOrder(t *testing.T) {
@@ -569,8 +573,177 @@ cmd-b:
     prod:
         echo b-prod
 `
-	_, _, _, envOrder, err := ParseOpsFile(writeTempOpsfile(t, content))
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
 	require.NoError(t, err)
 	// Deduplicated, first-appearance order: prod, local, preprod
-	assert.Equal(t, []string{"prod", "local", "preprod"}, envOrder)
+	assert.Equal(t, []string{"prod", "local", "preprod"}, parsed.EnvOrder)
+}
+
+// --- ShellLine prefix parsing tests ---
+
+func TestParseOpsFile_AtPrefixParsed(t *testing.T) {
+	content := `
+my-cmd:
+    prod:
+        @echo hello
+`
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
+	require.NoError(t, err)
+	lines := parsed.Commands["my-cmd"].Environments["prod"]
+	require.Len(t, lines, 1)
+	assert.Equal(t, "echo hello", lines[0].Text)
+	assert.True(t, lines[0].Silent)
+	assert.False(t, lines[0].IgnoreError)
+}
+
+func TestParseOpsFile_DashPrefixParsed(t *testing.T) {
+	content := `
+my-cmd:
+    prod:
+        -echo hello
+`
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
+	require.NoError(t, err)
+	lines := parsed.Commands["my-cmd"].Environments["prod"]
+	require.Len(t, lines, 1)
+	assert.Equal(t, "echo hello", lines[0].Text)
+	assert.False(t, lines[0].Silent)
+	assert.True(t, lines[0].IgnoreError)
+}
+
+func TestParseOpsFile_AtDashPrefixParsed(t *testing.T) {
+	content := `
+my-cmd:
+    prod:
+        @-echo hello
+`
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
+	require.NoError(t, err)
+	lines := parsed.Commands["my-cmd"].Environments["prod"]
+	require.Len(t, lines, 1)
+	assert.Equal(t, "echo hello", lines[0].Text)
+	assert.True(t, lines[0].Silent)
+	assert.True(t, lines[0].IgnoreError)
+}
+
+func TestParseOpsFile_DashAtPrefixParsed(t *testing.T) {
+	content := `
+my-cmd:
+    prod:
+        -@echo hello
+`
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
+	require.NoError(t, err)
+	lines := parsed.Commands["my-cmd"].Environments["prod"]
+	require.Len(t, lines, 1)
+	assert.Equal(t, "echo hello", lines[0].Text)
+	assert.True(t, lines[0].Silent)
+	assert.True(t, lines[0].IgnoreError)
+}
+
+func TestParseOpsFile_NoPrefixParsed(t *testing.T) {
+	content := `
+my-cmd:
+    prod:
+        echo hello
+`
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
+	require.NoError(t, err)
+	lines := parsed.Commands["my-cmd"].Environments["prod"]
+	require.Len(t, lines, 1)
+	assert.Equal(t, "echo hello", lines[0].Text)
+	assert.False(t, lines[0].Silent)
+	assert.False(t, lines[0].IgnoreError)
+}
+
+func TestParseOpsFile_AtPrefixWithBackslashContinuation(t *testing.T) {
+	content := `
+my-cmd:
+    prod:
+        @aws logs \
+            --follow
+`
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
+	require.NoError(t, err)
+	lines := parsed.Commands["my-cmd"].Environments["prod"]
+	require.Len(t, lines, 1)
+	assert.Equal(t, "aws logs --follow", lines[0].Text)
+	assert.True(t, lines[0].Silent)
+}
+
+func TestParseOpsFile_AtPrefixWithIndentContinuation(t *testing.T) {
+	content := `
+my-cmd:
+    prod:
+        @aws logs
+            --follow
+`
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
+	require.NoError(t, err)
+	lines := parsed.Commands["my-cmd"].Environments["prod"]
+	require.Len(t, lines, 1)
+	assert.Equal(t, "aws logs --follow", lines[0].Text)
+	assert.True(t, lines[0].Silent)
+}
+
+func TestParseOpsFile_AtOnContinuationFragment(t *testing.T) {
+	// @ on a non-first continuation fragment is part of the joined shell text,
+	// not Opsfile syntax (per FR-5).
+	content := `
+my-cmd:
+    prod:
+        aws logs \
+            @--follow
+`
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
+	require.NoError(t, err)
+	lines := parsed.Commands["my-cmd"].Environments["prod"]
+	require.Len(t, lines, 1)
+	assert.Equal(t, "aws logs @--follow", lines[0].Text)
+	assert.False(t, lines[0].Silent)
+}
+
+func TestParseOpsFile_DashPrefixWithBackslashContinuation(t *testing.T) {
+	content := `
+my-cmd:
+    prod:
+        -aws logs \
+            --follow
+`
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
+	require.NoError(t, err)
+	lines := parsed.Commands["my-cmd"].Environments["prod"]
+	require.Len(t, lines, 1)
+	assert.Equal(t, "aws logs --follow", lines[0].Text)
+	assert.True(t, lines[0].IgnoreError)
+}
+
+func TestParseOpsFile_DoubleAtPrefixParsed(t *testing.T) {
+	content := `
+my-cmd:
+    prod:
+        @@echo hello
+`
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
+	require.NoError(t, err)
+	lines := parsed.Commands["my-cmd"].Environments["prod"]
+	require.Len(t, lines, 1)
+	// First @ sets silent, second @ is part of the text.
+	assert.Equal(t, "@echo hello", lines[0].Text)
+	assert.True(t, lines[0].Silent)
+}
+
+func TestParseOpsFile_DoubleDashPrefixParsed(t *testing.T) {
+	content := `
+my-cmd:
+    prod:
+        --echo hello
+`
+	parsed, err := ParseOpsFile(writeTempOpsfile(t, content))
+	require.NoError(t, err)
+	lines := parsed.Commands["my-cmd"].Environments["prod"]
+	require.Len(t, lines, 1)
+	// First - sets ignoreError, second - is part of the text.
+	assert.Equal(t, "-echo hello", lines[0].Text)
+	assert.True(t, lines[0].IgnoreError)
 }


### PR DESCRIPTION
## Key Changes

- **`ParsedOpsfile` struct** — `ParseOpsFile` now returns a single struct instead of 5 values, eliminating the multi-return anti-pattern across all call sites
- **`ShellLine` struct** — parse-time type carrying `Text`, `Silent` (`@` prefix), and `IgnoreError` (`-` prefix); prefix stripping moved from resolver to parser where it belongs
- **`envLookup` injection** — `Resolve` now accepts `func(string)(string, bool)` instead of hardcoding `os.LookupEnv`, enabling proper unit testing without `os.Setenv`
- **CommandArgs passthrough (bug fix)** — `Args.CommandArgs` was populated but never passed through to `Execute`; fixed via POSIX `sh -c "script" ops arg1 arg2` so `$1`, `$2`, `$@`, and `$0` work correctly in Opsfile shell lines
- **`dryRun` in executor** — `Execute` now owns dry-run logic (previously in `main.go`); prints lines without executing, respecting per-line `Silent` flag
- **`DefaultShell()` in executor** — shell detection moved from `main.go` into the executor package that uses it
- **`formatCommandList` moved to `cmd/ops`** — presentation concern removed from `internal`; `lister.go`/`lister_test.go` relocated and made unexported
- **`examples/Opsfile_maclocal`** — new macOS local dev example covering resource checks, port management, log tailing, DNS flush, and network diagnostics

## Why do we need this?

The `internal` package had accumulated presentation logic (`lister.go`), mixed responsibilities in the executor (shell detection, dry-run), and a fragile 5-return-value API from `ParseOpsFile`. The CommandArgs bug meant `ops deploy myapp` never actually passed `myapp` as `$1` to the shell. This PR addresses all of these as identified in an architecture review.

## New modules or other dependencies introduced

None.

## How was this tested?

- All existing tests updated for the new APIs — no tests weakened or removed
- New test groups added: `ShellLine` prefix parsing, dry-run executor behavior, CommandArgs passthrough (`$1`/`$2`/`$@`/`$0`/spaces-in-args), `DefaultShell` edge cases, `nil`-safety for `envFileVars` and lister slices
- A QA agent review was performed post-implementation; all identified gaps addressed
- `make lint` and `make test` pass (also verified by pre-push hook)